### PR TITLE
Paf tests and merge clean up

### DIFF
--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -12,6 +12,8 @@ function notBothOptions(vals) {
   const values = _.castArray(vals);
   return !(values.length > 1 && values.indexOf('crime-transport-unknown') > -1);
 }
+const moment = require('moment');
+const PRETTY_DATE_FORMAT = 'Do MMMM YYYY';
 
 module.exports = {
   'crime-type': {
@@ -882,7 +884,8 @@ module.exports = {
   },
   'personAddDob': dateComponent('personAddDob', {
     isPageHeading: true,
-    mixin: 'input-date'
+    mixin: 'input-date',
+    parse: d => d && moment(d).format(PRETTY_DATE_FORMAT)
   }),
   'personAddAgeRange': {
     mixin: 'radio-group',

--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -574,6 +574,18 @@ module.exports = {
     mixin: 'radio-group',
     options: ['yes', 'no', 'unknown']
   },
+  'report-person-first-name': {
+    mixin: 'input-text'
+  },
+  'report-person-family-name': {
+    mixin: 'input-text'
+  },
+  'report-person-nickname': {
+    mixin: 'input-text'
+  },
+  'report-person-place-of-birth': {
+    mixin: 'input-text'
+  },
   'report-person-dob': dateComponent('report-person-dob', {
     isPageHeading: true,
     mixin: 'input-date'
@@ -611,6 +623,15 @@ module.exports = {
       'unknown'
     ]
   },
+  'report-person-passport': {
+    mixin: 'input-text'
+  },
+  'report-person-id': {
+    mixin: 'input-text'
+  },
+  'report-person-ni': {
+    mixin: 'input-text'
+  },
   'report-person-location': {
     mixin: 'radio-group',
     isPageHeading: true,
@@ -619,6 +640,12 @@ module.exports = {
       'outside-uk',
       'travel-to-uk',
       'unknown']
+  },
+  'report-person-location-uk-address-line1': {
+    mixin: 'input-text'
+  },
+  'report-person-location-uk-address-line2': {
+    mixin: 'input-text'
   },
   'report-person-location-uk-address-town': {
     className: ['govuk-input', 'govuk-!-width-two-thirds']
@@ -638,6 +665,12 @@ module.exports = {
         value: '',
         label: 'fields.report-person-location-outside-uk-address-country.options.null'
       }].concat(countriesList)
+  },
+  'report-person-location-outside-uk-address-line1': {
+    mixin: 'input-text'
+  },
+  'report-person-location-outside-uk-address-line2': {
+    mixin: 'input-text'
   },
   'report-person-location-outside-uk-address-town': {
     className: ['govuk-input', 'govuk-!-width-two-thirds']
@@ -690,10 +723,25 @@ module.exports = {
         label: 'fields.report-person-occupation-type.options.null'
       }].concat(occupation)
   },
+  'report-person-occupation-hours': {
+    mixin: 'input-text'
+  },
+  'report-person-occupation-days': {
+    mixin: 'input-text'
+  },
   'report-person-occupation-where': {
     isPageHeading: true,
     mixin: 'radio-group',
     options: ['yes', 'no', 'unknown']
+  },
+  'report-person-occupation-company-name': {
+    mixin: 'input-text'
+  },
+  'report-person-occupation-company-address-line1': {
+    mixin: 'input-text'
+  },
+  'report-person-occupation-company-address-line2': {
+    mixin: 'input-text'
   },
   'report-person-occupation-company-address-town': {
     className: ['govuk-input', 'govuk-!-width-two-thirds']
@@ -708,6 +756,9 @@ module.exports = {
   'report-person-occupation-company-phone': {
     className: ['govuk-input', 'govuk-input--width-20']
   },
+  'report-person-occupation-company-manager': {
+    mixin: 'input-text'
+  },
   'report-person-occupation-company-manager-know': {
     mixin: 'radio-group',
     options: ['yes', 'no', 'unknown']
@@ -716,6 +767,9 @@ module.exports = {
     mixin: 'radio-group',
     isPageHeading: true,
     options: ['yes', 'no', 'unknown']
+  },
+  'report-person-study-subject': {
+    mixin: 'input-text'
   },
   'report-person-study-location': {
     isPageHeading: true,
@@ -726,6 +780,21 @@ module.exports = {
     isPageHeading: true,
     mixin: 'radio-group',
     options: ['yes', 'no', 'unknown']
+  },
+  'report-person-study-hours': {
+    mixin: 'input-text'
+  },
+  'report-person-study-days': {
+    mixin: 'input-text'
+  },
+  'report-person-study-name': {
+    mixin: 'input-text'
+  },
+  'report-person-study-address-line1': {
+    mixin: 'input-text'
+  },
+  'report-person-study-address-line2': {
+    mixin: 'input-text'
   },
   'report-person-study-address-town': {
     className: ['govuk-input', 'govuk-!-width-two-thirds']
@@ -739,6 +808,15 @@ module.exports = {
   },
   'report-person-study-phone': {
     className: ['govuk-input', 'govuk-input--width-20']
+  },
+  'report-person-study-email': {
+    validate: ['email']
+  },
+  'report-person-study-url': {
+    mixin: 'input-text'
+  },
+  'report-person-study-manager': {
+    mixin: 'input-text'
   },
   'report-person-study-manager-know': {
     mixin: 'radio-group',
@@ -855,6 +933,21 @@ module.exports = {
       value: 'vans'
     },
   },
+  'report-person-transport-make': {
+    mixin: 'input-text'
+  },
+  'report-person-transport-model': {
+    mixin: 'input-text'
+  },
+  'report-person-transport-colour': {
+    mixin: 'input-text'
+  },
+  'report-person-transport-registration': {
+    mixin: 'input-text'
+  },
+  'report-person-transport-other': {
+    mixin: 'input-text'
+  },
   'report-person-description': {
     mixin: 'textarea',
     'ignore-defaults': true,
@@ -930,99 +1023,6 @@ module.exports = {
     mixin: 'input-text'
   },
   'personAddNi': {
-    mixin: 'input-text'
-  },
-  "does-anyone-else-know": {
-    mixin: 'input-text',
-    isPageHeading: true
-  },
-
-  "have-you-reported-before": {
-    mixin: 'input-text',
-    isPageHeading: true
-  },
-
-  "how-do-you-know-the-person": {
-    mixin: 'input-text',
-    isPageHeading: true
-  },
-
-  'can-use-info-without-risk': {
-    mixin: 'radio-group',
-    isPageHeading: true,
-    options: [
-      'yes',
-      'no',
-    ]
-  },
-  'about-you-dob': dateComponent('about-you-dob', {
-    isPageHeading: true,
-    mixin: 'input-date'
-  }),
-  'about-you-nationality': {
-    isPageHeading: true,
-    mixin: 'select',
-    className: 'typeahead',
-    options:
-      [{
-        value: '',
-    label: 'fields.about-you-nationality.options.null'
-      }].concat(nationalities)
-  },
-  'about-you-gender': {
-    mixin: 'radio-group',
-    isPageHeading: true,
-    options: [
-      'male',
-      'female',
-      'other',
-      'unknown'
-    ]
-  },
-  'about-you-contact': {
-    mixin: 'radio-group',
-    isPageHeading: true,
-    options: [
-      'yes',
-      'no',
-    ]
-  },
-  'are-you-eighteen': {
-    mixin: 'radio-group',
-    isPageHeading: true,
-
-    options: [{
-      value:'yes',
-      toggle:'contact-group',
-      child: 'partials/contact-group'
-    },
-      'no'
-    ]
-  },
-  'contact-group':{
-    "contact-number": {
-      "label": "Contact number"
-    },
-      "when-to-contact": {
-        "label": "When would you like us to contact you?"
-    },
-  },
-  'contact-number': {
-    dependent: {
-      field: 'are-you-eighteen',
-      value: 'yes'
-    }
-  },
-  'when-to-contact': {
-    dependent: {
-      field: 'are-you-eighteen',
-      value: 'yes'
-    }
-  },
-  'about-you-first-name': {
-    mixin: 'input-text'
-  },
-  'about-you-family-name': {
     mixin: 'input-text'
   },
   'report-organisation': {
@@ -1111,5 +1111,95 @@ module.exports = {
       field: 'another-company',
       value: 'yes'
     },
+  },
+  'about-you-first-name': {
+    mixin: 'input-text'
+  },
+  'about-you-family-name': {
+    mixin: 'input-text'
+  },
+  "does-anyone-else-know": {
+    mixin: 'input-text',
+    isPageHeading: true
+  },
+  "have-you-reported-before": {
+    mixin: 'input-text',
+    isPageHeading: true
+  },
+  "how-do-you-know-the-person": {
+    mixin: 'input-text',
+    isPageHeading: true
+  },
+  'can-use-info-without-risk': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    options: [
+      'yes',
+      'no',
+    ]
+  },
+  'about-you-dob': dateComponent('about-you-dob', {
+    isPageHeading: true,
+    mixin: 'input-date'
+  }),
+  'about-you-nationality': {
+    isPageHeading: true,
+    mixin: 'select',
+    className: 'typeahead',
+    options:
+      [{
+        value: '',
+        label: 'fields.about-you-nationality.options.null'
+      }].concat(nationalities)
+  },
+  'about-you-gender': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    options: [
+      'male',
+      'female',
+      'other',
+      'unknown'
+    ]
+  },
+  'about-you-contact': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    options: [
+      'yes',
+      'no',
+    ]
+  },
+  'are-you-eighteen': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+
+    options: [{
+      value: 'yes',
+      toggle: 'contact-group',
+      child: 'partials/contact-group'
+    },
+      'no'
+    ]
+  },
+  'contact-group': {
+    "contact-number": {
+      "label": "Contact number"
+    },
+    "when-to-contact": {
+      "label": "When would you like us to contact you?"
+    },
+  },
+  'contact-number': {
+    dependent: {
+      field: 'are-you-eighteen',
+      value: 'yes'
+    }
+  },
+  'when-to-contact': {
+    dependent: {
+      field: 'are-you-eighteen',
+      value: 'yes'
+    }
   }
 };

--- a/apps/paf/sections/summary-data-sections.js
+++ b/apps/paf/sections/summary-data-sections.js
@@ -9,10 +9,10 @@ module.exports = {
   'crime-type': [
     'crime-type',
     'immigration-crime-group',
-    'smuggling-crime-group',
+    'smuggling-crime-group'
   ],
   'crime-children': [
-    'crime-children',
+    'crime-children'
   ],
   'crime-time': [
     'when-crime-happened',
@@ -25,7 +25,7 @@ module.exports = {
       parse: d => d && moment(d).format(PRETTY_DATE_FORMAT)
     },
     'time-crime-will-happen',
-    'when-will-crime-happen-more-info',
+    'when-will-crime-happen-more-info'
   ],
   'crime-transport': [
     'crime-transport',
@@ -61,13 +61,13 @@ module.exports = {
     'airport-departure',
     'airport-arrival',
     'airport-departure-time',
-    'airport-arrival-time',
+    'airport-arrival-time'
   ],
   'crime-delivery': [
     'crime-delivery',
     'freight-more-info',
     'express-more-info',
-    'post-more-info',
+    'post-more-info'
   ],
   'crime-location': [
     'crime-location',
@@ -88,7 +88,7 @@ module.exports = {
     'crime-another-location-phone'
   ],
   person: [
-    'report-person',
+    'report-person'
   ],
   'personal-details': [
     'report-person-first-name',
@@ -101,12 +101,12 @@ module.exports = {
     'report-person-age-range',
     'report-person-nationality',
     'report-person-place-of-birth',
-    'report-person-gender',
+    'report-person-gender'
   ],
   'person-id': [
     'report-person-passport',
     'report-person-id',
-    'report-person-ni',
+    'report-person-ni'
   ],
   'person-contact': [
     'report-person-location',
@@ -164,7 +164,7 @@ module.exports = {
     'report-person-study-email',
     'report-person-study-url',
     'report-person-study-manager',
-    'report-person-study-manager-know',
+    'report-person-study-manager-know'
   ],
   'person-transport': [
     'report-person-transport',
@@ -177,7 +177,7 @@ module.exports = {
     'report-person-transport-model',
     'report-person-transport-colour',
     'report-person-transport-registration',
-    'report-person-transport-other',
+    'report-person-transport-other'
   ],
   'person-description': [
     'report-person-description'

--- a/apps/paf/sections/summary-data-sections.js
+++ b/apps/paf/sections/summary-data-sections.js
@@ -214,13 +214,13 @@ module.exports = {
     'another-company',
     'another-company-yes'
   ],
-  'other-info': [
-    'other-info-file-upload',
-    {
-      step: '/add-other-info-file-upload',
-      field: 'other-info-file-upload'
-    }
-  ],
+  // 'other-info': [
+  //   'other-info-file-upload',
+  //   {
+  //     step: '/add-other-info-file-upload',
+  //     field: 'other-info-file-upload'
+  //   }
+  // ],
   'about-you': [
     'how-did-you-find-out-about-the-crime',
     'does-anyone-else-know',

--- a/apps/paf/sections/summary-data-sections.js
+++ b/apps/paf/sections/summary-data-sections.js
@@ -214,13 +214,6 @@ module.exports = {
     'another-company',
     'another-company-yes'
   ],
-  // 'other-info': [
-  //   'other-info-file-upload',
-  //   {
-  //     step: '/add-other-info-file-upload',
-  //     field: 'other-info-file-upload'
-  //   }
-  // ],
   'about-you': [
     'how-did-you-find-out-about-the-crime',
     'does-anyone-else-know',

--- a/apps/paf/translations/src/en/pages.json
+++ b/apps/paf/translations/src/en/pages.json
@@ -138,43 +138,43 @@
     "header": "Check your answers before submitting your application.",
     "sections": {
       "crime-type": {
-        "header": "Crime Details - Crime Type"
+        "header": "The Crime - Crime Type"
       },
       "crime-children": {
-        "header": "Crime Details - Children Involved in Crime"
+        "header": "The Crime - Children Involved in Crime"
       },
       "crime-time": {
-        "header": "Crime Details - Duration"
+        "header": "The Crime - Duration"
       },
       "crime-transport": {
-        "header": "Crime Details - Transport Details"
+        "header": " The Crime - Transport Details"
       },
       "crime-delivery": {
-        "header": "Crime Details - Mode of Delivery "
+        "header": "The Crime - Mode of Delivery "
       },
       "crime-location": {
-        "header": "Crime Details - Location Details"
+        "header": "The Crime - Location Details"
       },
       "person": {
-        "header": "Report a Person"
+        "header": "The Person"
       },
       "personal-details": {
-        "header": "Person's Personal Details"
+        "header": "The Person - Personal Details"
       },
       "person-id": {
-        "header": "Person's Identification Details"
+        "header": "The Person - Identification Details"
       },
       "person-contact": {
-        "header": "Person's Contact Details"
+        "header": "The Person - Contact Details"
       },
       "person-occupation": {
-        "header": "Person's Occupation Details"
+        "header": "The Person - Occupation Details"
       },
       "person-study": {
-        "header": "Person's Study Details"
+        "header": "The Person - Study Details"
       },
       "person-transport": {
-        "header": "Person's Transport Details"
+        "header": "The Person - Transport Details"
       },
       "person-description": {
         "header": "The Person - Other Information"

--- a/config.js
+++ b/config.js
@@ -5,4 +5,5 @@ const env = process.env.NODE_ENV;
 
 module.exports = {
   env: env,
+  PRETTY_DATE_FORMAT: 'Do MMMM YYYY'
 };

--- a/test/_ui-integration/paf/application.spec.js
+++ b/test/_ui-integration/paf/application.spec.js
@@ -141,10 +141,114 @@ describe('the journey of a paf application', () => {
     expect(response.text).to.contain('Found. Redirecting to /paf/report-person');
   });
 
-  it('goes to the report-organisation page', async () => {
+  it('goes to the report-person-name page', async () => {
     const URI = '/report-person';
     await initSession(URI);
+    const response = await passStep(URI, {
+      'report-person': 'yes'
+    });
+    expect(response.text).to.contain('Found. Redirecting to /paf/report-person-name');
+  });
+
+  it('goes to the report-person-dob page', async () => {
+    const URI = '/report-person-name';
+    await initSession(URI);
     const response = await passStep(URI, {});
+    expect(response.text).to.contain('Found. Redirecting to /paf/report-person-dob');
+  });
+
+  it('goes to the report-person-age-range page', async () => {
+    const URI = '/report-person-dob';
+    await initSession(URI);
+    const response = await passStep(URI, {});
+    expect(response.text).to.contain('Found. Redirecting to /paf/report-person-age-range');
+  });
+
+  it('goes to the report-person-nationality page', async () => {
+    const URI = '/report-person-age-range';
+    await initSession(URI);
+    const response = await passStep(URI, {});
+    expect(response.text).to.contain('Found. Redirecting to /paf/report-person-nationality');
+  });
+
+  it('goes to the report-person-place-of-birth page', async () => {
+    const URI = '/report-person-nationality';
+    await initSession(URI);
+    const response = await passStep(URI, {});
+    expect(response.text).to.contain('Found. Redirecting to /paf/report-person-place-of-birth');
+  });
+
+  it('goes to the report-person-gender page', async () => {
+    const URI = '/report-person-place-of-birth';
+    await initSession(URI);
+    const response = await passStep(URI, {});
+    expect(response.text).to.contain('Found. Redirecting to /paf/report-person-gender');
+  });
+
+  it('goes to the report-person-id page', async () => {
+    const URI = '/report-person-gender';
+    await initSession(URI);
+    const response = await passStep(URI, {});
+    expect(response.text).to.contain('Found. Redirecting to /paf/report-person-id');
+  });
+
+  it('goes to the report-person-location page', async () => {
+    const URI = '/report-person-id';
+    await initSession(URI);
+    const response = await passStep(URI, {});
+    expect(response.text).to.contain('Found. Redirecting to /paf/report-person-location');
+  });
+
+  it('goes to the report-person-occupation page', async () => {
+    const URI = '/report-person-location';
+    await initSession(URI);
+    const response = await passStep(URI, {});
+    expect(response.text).to.contain('Found. Redirecting to /paf/report-person-occupation');
+  });
+
+  it('goes to the report-person-study page', async () => {
+    const URI = '/report-person-occupation';
+    await initSession(URI);
+    const response = await passStep(URI, {});
+    expect(response.text).to.contain('Found. Redirecting to /paf/report-person-study');
+  });
+
+  it('goes to the report-person-transport page', async () => {
+    const URI = '/report-person-study';
+    await initSession(URI);
+    const response = await passStep(URI, {});
+    expect(response.text).to.contain('Found. Redirecting to /paf/report-person-transport');
+  });
+
+  it('goes to the report-person-description page', async () => {
+    const URI = '/report-person-transport';
+    await initSession(URI);
+    const response = await passStep(URI, {});
+    expect(response.text).to.contain('Found. Redirecting to /paf/report-person-description');
+  });
+
+  it('goes to the has-additionalPerson page', async () => {
+    const URI = '/report-person-description';
+    await initSession(URI);
+    const response = await passStep(URI, {});
+    expect(response.text).to.contain('Found. Redirecting to /paf/has-additionalPerson');
+  });
+
+  it('goes to the person-details page when the user has additional people to add', async () => {
+    const URI = '/has-additionalPerson';
+    await initSession(URI);
+    const response = await passStep(URI, {
+      'hasAdditionalPerson': 'yes'
+    });
+    expect(response.text).to.contain('Found. Redirecting to /paf/person-details');
+  });
+
+  it('goes to the report-organisation page when the user has no additional people to add', async () => {
+    const URI = '/has-additionalPerson';
+    await initSession(URI);
+    const response = await passStep(URI, {
+      'hasAdditionalPerson': 'no'
+    });
     expect(response.text).to.contain('Found. Redirecting to /paf/report-organisation');
   });
 

--- a/test/_unit/behaviours/aggregator.spec.js
+++ b/test/_unit/behaviours/aggregator.spec.js
@@ -1,0 +1,624 @@
+
+const AggregatorBehaviour = require('../../../apps/paf/behaviours/aggregator');
+const Model = require('hof').model;
+const moment = require('moment');
+
+
+describe('aggregator behaviour', () => {
+  class Base {
+  }
+
+  let behaviour;
+  let Behaviour;
+  let req;
+  let res;
+  let next;
+
+  describe('aggregator', () => {
+    let superGetValuesStub;
+    let superLocalsStub;
+
+    beforeEach(() => {
+      req = request();
+      res = response();
+
+      req.sessionModel = new Model({});
+      req.form.options = {
+        aggregateFrom: ['personAddNumber',
+          'personAddFirstName',
+          'personAddFamilyName',
+          'personAddNickname',
+          'personAddDob',
+          'personAddAgeRange',
+          'personAddNationality',
+          'personAddPlaceOfBirth',
+          'personAddGender',
+          'personAddPassport',
+          'personAddId',
+          'personAddNi'],
+        aggregateTo: 'persons',
+        addStep: 'add-person',
+        route: '/person-details',
+        addAnotherLinkText: 'person',
+        fieldsConfig: {
+          personAddNumber: {},
+          personAddFirstName: {},
+          personAddFamilyName: {},
+          personAddNickname: {},
+          personAddDob: {},
+          personAddAgeRange: {},
+          personAddNationality: {},
+          personAddPlaceOfBirth: {},
+          personAddGender: {},
+          personAddPassport: {},
+          personAddId: {},
+          personAddNi: {}
+        }
+      };
+      req.baseUrl = '/test';
+
+      superGetValuesStub = sinon.stub();
+      superLocalsStub = sinon.stub();
+      Base.prototype.getValues = superGetValuesStub;
+      Base.prototype.locals = superLocalsStub;
+      next = sinon.stub();
+
+      Behaviour = AggregatorBehaviour(Base);
+      behaviour = new Behaviour(req.form.options);
+      behaviour.confirmStep = '/confirm';
+    });
+
+    describe('#getValues actions', () => {
+      beforeEach(() => {
+        behaviour.handleAction = sinon.stub();
+      });
+
+      it('sends the delete action when url action is delete', () => {
+        req.params.action = 'delete';
+        behaviour.getValues(req, res, next);
+
+        behaviour.handleAction.should.be.calledOnceWithExactly(req, res, next, 'delete');
+      });
+
+      it('sends the edit action when url action is edit', () => {
+        req.params.action = 'edit';
+        behaviour.getValues(req, res, next);
+
+        behaviour.handleAction.should.be.calledOnceWithExactly(req, res, next, 'edit');
+      });
+
+      it('sends the addItem action when url action is missing, but new fields to add are present, ' +
+        'and no elements exist', () => {
+          req.form.options.aggregateFrom = ['personAddNumber',
+            'personAddFirstName',
+            'personAddFamilyName',
+            'personAddNickname',
+            'personAddDob',
+            'personAddAgeRange',
+            'personAddNationality',
+            'personAddPlaceOfBirth',
+            'personAddGender',
+            'personAddPassport',
+            'personAddId',
+            'personAddNi'];
+
+          req.sessionModel.set('personAddFirstName', 'Ronald');
+          req.sessionModel.set('personAddFamilyName', 'Testman');
+
+          behaviour.getValues(req, res, next);
+
+          behaviour.handleAction.should.be.calledOnceWithExactly(req, res, next, 'addItem');
+        });
+
+      it('sends the addItem action when url action is missing, but new fields to add are present, ' +
+        'and elements already exist', () => {
+          req.form.options.aggregateFrom = ['personAddNumber',
+            'personAddFirstName',
+            'personAddFamilyName',
+            'personAddNickname',
+            'personAddDob',
+            'personAddAgeRange',
+            'personAddNationality',
+            'personAddPlaceOfBirth',
+            'personAddGender',
+            'personAddPassport',
+            'personAddId',
+            'personAddNi'];
+
+          req.sessionModel.set('persons', [{ itemTitle: '', fields: {} }]);
+
+
+          req.sessionModel.set('personAddFirstName', 'Ronald');
+          req.sessionModel.set('personAddFamilyName', 'Testman');
+
+          behaviour.getValues(req, res, next);
+
+          behaviour.handleAction.should.be.calledOnceWithExactly(req, res, next, 'addItem');
+        });
+
+      it('sends the redirectToAddStep action when url action is not present, no new fields to add are present, ' +
+        'and no elements have been added', () => {
+          req.form.options.aggregateFrom = ['personAddNumber',
+            'personAddFirstName',
+            'personAddFamilyName',
+            'personAddNickname',
+            'personAddDob',
+            'personAddAgeRange',
+            'personAddNationality',
+            'personAddPlaceOfBirth',
+            'personAddGender',
+            'personAddPassport',
+            'personAddId',
+            'personAddNi'];
+          behaviour.getValues(req, res, next);
+
+          behaviour.handleAction.should.be.calledOnceWithExactly(req, res, next, 'redirectToAddStep');
+        });
+    });
+
+    describe('#handleAction', () => {
+      beforeEach(() => {
+        behaviour.deleteItem = sinon.stub();
+        behaviour.editItem = sinon.stub();
+        behaviour.addItem = sinon.stub();
+        behaviour.redirectToAddStep = sinon.stub();
+      });
+
+      it('calls deleteItem when the action is delete', () => {
+        behaviour.handleAction(req, res, next, 'delete').redirected.should.be.true;
+        behaviour.deleteItem.should.be.calledOnceWithExactly(req, res);
+      });
+
+      it('calls editItem when the action is edit', () => {
+        behaviour.handleAction(req, res, next, 'edit').redirected.should.be.true;
+        behaviour.editItem.should.be.calledOnceWithExactly(req, res);
+      });
+
+      it('calls addItem when the action is addItem', () => {
+        behaviour.handleAction(req, res, next, 'addItem').redirected.should.be.true;
+        behaviour.addItem.should.be.calledOnceWithExactly(req, res);
+      });
+
+      it('calls redirectToAddStep when the action is redirectToAddStep', () => {
+        behaviour.handleAction(req, res, next, 'redirectToAddStep').redirected.should.be.true;
+        behaviour.redirectToAddStep.should.be.calledOnceWithExactly(req, res);
+      });
+
+      it('calls super.getValues when the action is showItems', () => {
+        behaviour.handleAction(req, res, next, 'showItemsshowItems').redirected.should.be.false;
+        superGetValuesStub.should.be.calledOnceWithExactly(req, res, next);
+      });
+
+      it('calls super.getValues as a default', () => {
+        behaviour.handleAction(req, res, next, '');
+        superGetValuesStub.should.be.calledOnceWithExactly(req, res, next);
+      });
+    });
+
+    describe('delete item', () => {
+      beforeEach(() => {
+        req.sessionModel.set('persons', {
+          aggregatedValues: [
+            { itemTitle: 'Person 1', fields: [Array] },
+            { itemTitle: 'Person 2', fields: [Array] },
+          ]
+        });
+        req.params.id = '1';
+      });
+
+      it('deletes the item with the given id when the action is delete and an id is provide', () => {
+        behaviour.deleteItem(req, res);
+        req.sessionModel.get('persons').aggregatedValues.should.eql([
+          { itemTitle: 'Person 1', fields: [Array] }
+        ]);
+      });
+
+      it('redirects back to step after deletion', () => {
+        behaviour.deleteItem(req, res);
+        res.redirect.should.be.calledOnceWithExactly('/test/person-details');
+      });
+    });
+
+    describe('edit item', () => {
+      beforeEach(() => {
+        req.form.options.aggregateFrom = [
+          'personAddNumber',
+          'personAddFirstName',
+          'personAddFamilyName',
+          'personAddNickname',
+          'personAddDob',
+          'personAddAgeRange',
+          'personAddNationality',
+          'personAddPlaceOfBirth',
+          'personAddGender',
+          'personAddPassport',
+          'personAddId',
+          'personAddNi'
+        ];
+
+        req.sessionModel.set('persons', {
+          aggregatedValues: [
+            {
+              itemTitle: '',
+              fields: [{ field: 'personAddNumber', value: 'Person 1' },
+              { field: 'personAddFirstName', value: 'Ronald' },
+              { field: 'personAddFamilyName', value: 'Testman' },
+              { field: 'personAddNickname', value: '' },
+              { field: 'personAddDob', value: '2000-10-15' },
+              { field: 'personAddAgeRange', value: '' },
+              { field: 'personAddNationality', value: '' },
+              { field: 'personAddPlaceOfBirth', value: '' },
+              { field: 'personAddGender', value: '' },
+              { field: 'personAddPassport', value: '' },
+              { field: 'personAddId', value: '' },
+              { field: 'personAddNi', value: '' }
+              ]
+            },
+            {
+              itemTitle: '',
+              fields: [{ field: 'personAddNumber', value: 'Person 1' },
+              { field: 'personAddFirstName', value: 'Ronda' },
+              { field: 'personAddFamilyName', value: 'Testman' },
+              { field: 'personAddNickname', value: '' },
+              { field: 'personAddDob', value: '' },
+              { field: 'personAddAgeRange', value: '' },
+              { field: 'personAddNationality', value: '' },
+              { field: 'personAddPlaceOfBirth', value: '' },
+              { field: 'personAddGender', value: 'female' },
+              { field: 'personAddPassport', value: '' },
+              { field: 'personAddId', value: '' },
+              { field: 'personAddNi', value: '' }
+              ]
+            }
+          ]
+        });
+        req.params.id = '1';
+
+        behaviour.editItem(req, res);
+      });
+
+      it('populates the source form fields when the action is edit and an id is provided', () => {
+        req.sessionModel.get('personAddFirstName').should.eql('Ronda');
+        req.sessionModel.get('personAddFamilyName').should.eql('Testman');
+      });
+
+      it('redirects to the source form', () => {
+        res.redirect.should.be.calledOnceWithExactly('/test/add-person/edit');
+      });
+    });
+
+    describe('update item', () => {
+      beforeEach(() => {
+        req.form.options.aggregateFrom = [
+          'personAddNumber',
+          'personAddFirstName',
+          'personAddFamilyName',
+          'personAddNickname',
+          'personAddDob',
+          'personAddAgeRange',
+          'personAddNationality',
+          'personAddPlaceOfBirth',
+          'personAddGender',
+          'personAddPassport',
+          'personAddId',
+          'personAddNi'
+        ];
+        req.form.options.titleField = 'personAddNumber';
+        req.sessionModel.set('persons', {
+          aggregatedValues:
+            [
+              {
+                itemTitle: 'Person 1',
+                fields: [{ field: 'personAddNumber', value: 'Person 1' },
+                { field: 'personAddFirstName', value: 'Ronald' },
+                { field: 'personAddFamilyName', value: 'Testman' },
+                { field: 'personAddNickname', value: '' },
+                { field: 'personAddDob', value: '2000-10-15' },
+                { field: 'personAddAgeRange', value: '' },
+                { field: 'personAddNationality', value: '' },
+                { field: 'personAddPlaceOfBirth', value: '' },
+                { field: 'personAddGender', value: '' },
+                { field: 'personAddPassport', value: '' },
+                { field: 'personAddId', value: '' },
+                { field: 'personAddNi', value: '' }
+                ]
+              },
+              {
+                itemTitle: 'Person 2',
+                fields: [{ field: 'personAddNumber', value: 'Person 2' },
+                { field: 'personAddFirstName', value: 'Ronda' },
+                { field: 'personAddFamilyName', value: 'Testman' },
+                { field: 'personAddNickname', value: '' },
+                { field: 'personAddDob', value: '' },
+                { field: 'personAddAgeRange', value: '' },
+                { field: 'personAddNationality', value: '' },
+                { field: 'personAddPlaceOfBirth', value: '' },
+                { field: 'personAddGender', value: 'female' },
+                { field: 'personAddPassport', value: '' },
+                { field: 'personAddId', value: '' },
+                { field: 'personAddNi', value: '' }
+                ]
+              }
+            ]
+        });
+        req.sessionModel.set('persons-itemToReplaceId', 1);
+
+        req.sessionModel.set('personAddNumber', 'Person 2');
+        req.sessionModel.set('personAddFirstName', 'Buzz');
+        req.sessionModel.set('personAddFamilyName', 'Lightyear');
+        req.sessionModel.set('personAddNickname', 'Infinity');
+        req.sessionModel.set('personAddDob', '1995-11-2');
+        req.sessionModel.set('personAddAgeRange', '25-34');
+        req.sessionModel.set('personAddNationality', 'United States of America');
+        req.sessionModel.set('personAddPlaceOfBirth', 'California');
+        req.sessionModel.set('personAddGender', 'male');
+        req.sessionModel.set('personAddPassport', '123');
+        req.sessionModel.set('personAddId', '156');
+        req.sessionModel.set('personAddNi', 'TS1995');
+
+        behaviour.updateItem(req, res);
+      });
+
+      it('unsets field used to indicate an update operation', () => {
+        expect(req.sessionModel.get('persons-itemToReplaceId')).to.be.undefined;
+        expect(req.sessionModel.get('personAddNumber')).to.be.undefined;
+        expect(req.sessionModel.get('personAddFirstName')).to.be.undefined;
+        expect(req.sessionModel.get('personAddFamilyName')).to.be.undefined;
+        expect(req.sessionModel.get('personAddNickname')).to.be.undefined;
+        expect(req.sessionModel.get('personAddDob')).to.be.undefined;
+        expect(req.sessionModel.get('personAddAgeRange')).to.be.undefined;
+        expect(req.sessionModel.get('personAddNationality')).to.be.undefined;
+        expect(req.sessionModel.get('personAddPlaceOfBirth')).to.be.undefined;
+        expect(req.sessionModel.get('personAddGender')).to.be.undefined;
+        expect(req.sessionModel.get('personAddPassport')).to.be.undefined;
+        expect(req.sessionModel.get('personAddId')).to.be.undefined;
+        expect(req.sessionModel.get('personAddNi')).to.be.undefined;
+      });
+
+      it('replaces an item with the source step fields when itemToReplaceId is present ' +
+        'in the session and action is edit', () => {
+          const updatedElement = req.sessionModel.get('persons').aggregatedValues[1];
+
+          updatedElement.should.be.eql({
+            itemTitle: 'Person 2',
+            fields: [
+              { field: 'personAddNumber', value: 'Person 2', parsed: 'Person 2' },
+              { field: 'personAddFirstName', value: 'Buzz', parsed: 'Buzz' },
+              { field: 'personAddFamilyName', value: 'Lightyear', parsed: 'Lightyear' },
+              { field: 'personAddNickname', value: 'Infinity', parsed: 'Infinity' },
+              { field: 'personAddDob', value: '1995-11-2', parsed: '1995-11-2', },
+              { field: 'personAddAgeRange', value: '25-34', parsed: '25-34' },
+              { field: 'personAddNationality', value: 'United States of America', parsed: 'United States of America' },
+              { field: 'personAddPlaceOfBirth', value: 'California', parsed: 'California' },
+              { field: 'personAddGender', value: 'male', parsed: 'male' },
+              { field: 'personAddPassport', value: '123', parsed: '123' },
+              { field: 'personAddId', value: '156', parsed: '156' },
+              { field: 'personAddNi', value: 'TS1995', parsed: 'TS1995' }
+            ]
+          });
+        });
+
+      it('should return to the confirm step if user comes from summary', () => {
+        req.form.options.aggregateFrom = [
+          'personAddNumber',
+          'personAddFirstName',
+          'personAddFamilyName',
+          'personAddNickname',
+          'personAddDob',
+          'personAddAgeRange',
+          'personAddNationality',
+          'personAddPlaceOfBirth',
+          'personAddGender',
+          'personAddPassport',
+          'personAddId',
+          'personAddNi'
+        ];
+        req.form.options.titleField = 'personAddNumber';
+
+        req.sessionModel.set('persons', {
+          aggregatedValues: [
+            {
+              itemTitle: 'Person 1',
+              fields: [{ field: 'personAddNumber', value: 'Person 1' },
+              { field: 'personAddFirstName', value: 'Ronald' },
+              { field: 'personAddFamilyName', value: 'Testman' },
+              { field: 'personAddNickname', value: '' },
+              { field: 'personAddDob', value: '2000-10-15' },
+              { field: 'personAddAgeRange', value: '' },
+              { field: 'personAddNationality', value: '' },
+              { field: 'personAddPlaceOfBirth', value: '' },
+              { field: 'personAddGender', value: '' },
+              { field: 'personAddPassport', value: '' },
+              { field: 'personAddId', value: '' },
+              { field: 'personAddNi', value: '' }
+              ]
+            },
+            {
+              itemTitle: '',
+              fields: [{ field: 'personAddNumber', value: '' },
+              { field: 'personAddFirstName', value: 'Ronda' },
+              { field: 'personAddFamilyName', value: 'Testman' },
+              { field: 'personAddNickname', value: '' },
+              { field: 'personAddDob', value: '' },
+              { field: 'personAddAgeRange', value: '' },
+              { field: 'personAddNationality', value: '' },
+              { field: 'personAddPlaceOfBirth', value: '' },
+              { field: 'personAddGender', value: 'female' },
+              { field: 'personAddPassport', value: '' },
+              { field: 'personAddId', value: '' },
+              { field: 'personAddNi', value: '' }
+              ]
+            }
+          ]
+        });
+        req.params.action = 'edit';
+        req.sessionModel.set('persons-itemToReplaceId', 1);
+        req.sessionModel.set('personAddFirstName', 'Buzz');
+        req.sessionModel.set('personAddFamilyName', 'Lightyear');
+        req.sessionModel.set('returnToSummary', true);
+
+        behaviour.getValues(req, res, next);
+
+        res.redirect.should.be.calledWithExactly('/test/confirm');
+      });
+    });
+
+    describe('add item', () => {
+      beforeEach(() => {
+        req.form.options.aggregateFrom = [
+          'personAddNumber',
+          'personAddFirstName',
+          'personAddFamilyName',
+          'personAddNickname',
+          'personAddDob',
+          'personAddAgeRange',
+          'personAddNationality',
+          'personAddPlaceOfBirth',
+          'personAddGender',
+          'personAddPassport',
+          'personAddId',
+          'personAddNi'
+        ];
+        req.form.options.titleField = 'personAddNumber';
+
+        req.sessionModel.set('personAddNumber', 'Person 3');
+        req.sessionModel.set('personAddFirstName', 'Ronald');
+        req.sessionModel.set('personAddFamilyName', 'Testman');
+        req.sessionModel.set('personAddNickname', 'Testy');
+        req.sessionModel.set('personAddDob', '1996-10-22');
+        req.sessionModel.set('personAddAgeRange', '25-34');
+        req.sessionModel.set('personAddNationality', 'France');
+        req.sessionModel.set('personAddPlaceOfBirth', 'Paris');
+        req.sessionModel.set('personAddGender', 'male');
+        req.sessionModel.set('personAddPassport', '123');
+        req.sessionModel.set('personAddId', '156');
+        req.sessionModel.set('personAddNi', '');
+
+        req.sessionModel.set('persons', {
+          aggregatedValues: [
+            {
+              itemTitle: 'Person 1',
+              fields: [{ field: 'personAddFirstName', value: 'Buzz' },
+              { field: 'personAddFamilyName', value: 'Lightyear' },
+              ]
+            },
+            {
+              itemTitle: 'Person 2',
+              fields: [{ field: 'personAddFirstName', value: 'Tony' },
+              { field: 'personAddFamilyName', value: 'McTester' }
+              ]
+            }
+          ]
+        });
+
+        behaviour.addItem(req, res, next);
+      });
+
+      it('adds a new item', () => {
+        const addedElement = req.sessionModel.get('persons').aggregatedValues[2];
+
+        addedElement.should.be.eql({
+          itemTitle: 'Person 3',
+          fields: [
+            { field: 'personAddNumber', value: 'Person 3', changeField: undefined, parsed: 'Person 3', showInSummary: false },
+            { field: 'personAddFirstName', value: 'Ronald', changeField: undefined, parsed: 'Ronald', showInSummary: true },
+            { field: 'personAddFamilyName', value: 'Testman', changeField: undefined, parsed: 'Testman', showInSummary: true },
+            { field: 'personAddNickname', value: 'Testy', changeField: undefined, parsed: 'Testy', showInSummary: true },
+            { field: 'personAddDob', value: '1996-10-22', changeField: undefined, parsed: '1996-10-22', showInSummary: true },
+            { field: 'personAddAgeRange', value: '25-34', changeField: undefined, parsed: '25-34', showInSummary: true },
+            { field: 'personAddNationality', value: 'France', changeField: undefined, parsed: 'France', showInSummary: true },
+            { field: 'personAddPlaceOfBirth', value: 'Paris', changeField: undefined, parsed: 'Paris', showInSummary: true },
+            { field: 'personAddGender', value: 'male', changeField: undefined, parsed: 'male', showInSummary: true },
+            { field: 'personAddPassport', value: '123', changeField: undefined, parsed: '123', showInSummary: true },
+            { field: 'personAddId', value: '156', changeField: undefined, parsed: '156', showInSummary: true },
+            { field: 'personAddNi', value: '', changeField: undefined, parsed: '', showInSummary: true }
+          ]
+        });
+      });
+    });
+
+    describe('#locals', () => {
+      let result;
+      beforeEach(() => {
+        req.form.options.aggregateFrom = [
+          'personAddNumber',
+          'personAddFirstName',
+          'personAddFamilyName',
+          'personAddNickname',
+          'personAddDob',
+          'personAddAgeRange',
+          'personAddNationality',
+          'personAddPlaceOfBirth',
+          'personAddGender',
+          'personAddPassport',
+          'personAddId',
+          'personAddNi'
+        ];
+
+        req.sessionModel.set('persons', {
+          aggregatedValues: [
+            {
+              itemTitle: '',
+              fields: [
+                {
+                  field: 'personAddFirstName',
+                  value: 'John',
+                  showInSummary: false
+                }
+              ]
+            }
+          ]
+        });
+
+        result = behaviour.locals(req, res);
+      });
+
+      it('should call super', () => {
+        superLocalsStub.should.be.calledWithExactly(req, res);
+      });
+
+      it('should populate the correct items', () => {
+        result.should.containSubset({
+          items: [
+            {
+              itemTitle: '',
+              fields: [
+                {
+                  field: 'personAddFirstName',
+                  value: 'John',
+                  showInSummary: false
+                }
+              ],
+              index: 0
+            }
+          ],
+          hasItems: true,
+          addStep: 'add-person',
+          addAnotherLinkText: 'person',
+          field: 'persons'
+        });
+      });
+    });
+
+    describe('#parseField', () => {
+      it('it should run the field parser', () => {
+        req.form.options.aggregateTo = 'persons';
+        req.sessionModel = new Model({});
+
+        req.form.options.fieldsConfig =
+          { personAddDob: { parse: d => d && moment(d).format(config.PRETTY_DATE_FORMAT) } };
+
+        const value = 1970 - 01 - 01;
+
+        const field = {
+          field: 'personAddDob',
+          changeField: 'personAddDob-day'
+        };
+
+        const result = behaviour.parseField(field, value, req);
+
+        result.should.eql('1st January 1970');
+      });
+    });
+  });
+});

--- a/test/_unit/behaviours/limit-person.spec.js
+++ b/test/_unit/behaviours/limit-person.spec.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const Controller = require('hof').controller;
+const Behaviour = require('../../../apps/paf/behaviours/limit-person');
+
+describe('apps/paf/behaviours/limit-person', () => {
+  describe('locals', () => {
+    let controller;
+    let req;
+    let res;
+
+    beforeEach(done => {
+      req = reqres.req();
+      res = reqres.res();
+      const LimitPersonController = Behaviour(Controller);
+      controller = new LimitPersonController({ template: 'index', route: '/index' });
+      controller._configure(req, res, done);
+    });
+
+    describe('limit additional people', () => {
+
+      it('locals should not have noMorePersons property if additional people is less then 6', () => {
+        req.sessionModel.set('persons', {
+          aggregatedValues: [
+            { itemTitle: 'Person 1', fields: [Array] },
+            { itemTitle: 'Person 2', fields: [Array] },
+          ]
+        })
+        controller.locals(req, res).should.not.have.property('noMorePersons')
+      });
+
+      it('locals.noMorePersons is true if additional people is equal to or more then 6', () => {
+        req.sessionModel.set('persons', {
+          aggregatedValues: [
+            { itemTitle: 'Person 1', fields: [Array] },
+            { itemTitle: 'Person 2', fields: [Array] },
+            { itemTitle: 'Person 3', fields: [Array] },
+            { itemTitle: 'Person 4', fields: [Array] },
+            { itemTitle: 'Person 5', fields: [Array] },
+            { itemTitle: 'Person 6', fields: [Array] }
+          ]
+        })
+        controller.locals(req, res).should.have.property('noMorePersons')
+          .and.deep.equal(true);
+      });
+    });
+  });
+});

--- a/test/_unit/behaviours/transport-behaviour.spec.js
+++ b/test/_unit/behaviours/transport-behaviour.spec.js
@@ -46,7 +46,6 @@ describe('apps/paf/behaviours/transport-behaviour', () => {
         req.form.values['vehicle-registration'] = 'MRVL1';
 
         controller.saveValues(req, res, () => {
-          console.log(req.sessionModel)
           req.sessionModel.unset.should.have.been.calledWithExactly([
             'vehicle-type',
             'vehicle-make',
@@ -70,7 +69,6 @@ describe('apps/paf/behaviours/transport-behaviour', () => {
         req.form.values['port-arrival-time'] = '8pm';
 
         controller.saveValues(req, res, () => {
-          console.log(req.sessionModel)
           req.sessionModel.unset.should.have.been.calledWithExactly([
             'boat-type',
             'boat-name',
@@ -95,7 +93,6 @@ describe('apps/paf/behaviours/transport-behaviour', () => {
         req.form.values['station-arrival-time'] = '3pm';
 
         controller.saveValues(req, res, () => {
-          console.log(req.sessionModel)
           req.sessionModel.unset.should.have.been.calledWithExactly([
             'train-company',
             'train-country-departure',
@@ -120,7 +117,6 @@ describe('apps/paf/behaviours/transport-behaviour', () => {
         req.form.values['airport-arrival-time'] = '7pm';
 
         controller.saveValues(req, res, () => {
-          console.log(req.sessionModel)
           req.sessionModel.unset.should.have.been.calledWithExactly([
             'airline-company',
             'airline-flight-number',

--- a/test/_unit/sections/summary-data-sections.spec.js
+++ b/test/_unit/sections/summary-data-sections.spec.js
@@ -376,6 +376,62 @@ describe('PAF Summary Data Sections', () => {
       ).to.be.true;
     });
 
+    it('personal-details', () => {
+      expect(containsAll(
+        Object.keys(fields),
+        mappedSections['personal-details'])
+      ).to.be.true;
+    });
+
+    it('person-id', () => {
+      expect(containsAll(
+        Object.keys(fields),
+        mappedSections['person-id'])
+      ).to.be.true;
+    });
+
+    it('person-contact', () => {
+      expect(containsAll(
+        Object.keys(fields),
+        mappedSections['person-contact'])
+      ).to.be.true;
+    });
+
+    it('person-occupation', () => {
+      expect(containsAll(
+        Object.keys(fields),
+        mappedSections['person-occupation'])
+      ).to.be.true;
+    });
+
+    it('person-study', () => {
+      expect(containsAll(
+        Object.keys(fields),
+        mappedSections['person-study'])
+      ).to.be.true;
+    });
+
+    it('person-transport', () => {
+      expect(containsAll(
+        Object.keys(fields),
+        mappedSections['person-transport'])
+      ).to.be.true;
+    });
+
+    it('person-description', () => {
+      expect(containsAll(
+        Object.keys(fields),
+        mappedSections['person-description'])
+      ).to.be.true;
+    });
+
+    it('person-details', () => {
+      mappedSections['person-details'].every(i => {
+        const item = i.field || i;
+        return Object.keys(fields).includes(item);
+      });
+    });
+
     it('organisation', () => {
       expect(containsAll(
         Object.keys(fields),


### PR DESCRIPTION
## What
- Add unit and ui tests for person section
- Format date of birth fields
- Remove incomplete other-info section from summary data sections as they were causing tests to fail( they can be added back in once the section has been completed and added to check answers page)
- Amend check answers section headers for consistency
- Format field/index.js after rebase
## Why
- Test person section
- Improve consistency with field and header names
- Clean up after multiple branch merges
## Testing
tests passing locally