### PR TITLE
PAF-45: add 'other info' section pages

### DIFF
--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -1112,6 +1112,35 @@ module.exports = {
       value: 'yes'
     },
   },
+  'other-info-description': {
+    mixin: 'textarea',
+    'ignore-defaults': true,
+    formatter: ['trim', 'hyphens'],
+    validate: [{ type: 'maxlength', arguments: 1200 }],
+    attributes: [{ attribute: 'spellcheck', value: 'true' }, { attribute: 'rows', value: 8 }]
+  },
+  'other-info-another-crime': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    options: [{
+      value: 'yes',
+      toggle: 'other-info-another-crime-description',
+      child: 'textarea'
+    },
+      'no'
+    ]
+  },
+  'other-info-another-crime-description': {
+    mixin: 'textarea',
+    'ignore-defaults': true,
+    formatter: ['trim', 'hyphens'],
+    validate: [{ type: 'maxlength', arguments: 1200 }],
+    attributes: [{ attribute: 'spellcheck', value: 'true' }, { attribute: 'rows', value: 8 }],
+    dependent: {
+      field: 'other-info-another-crime',
+      value: 'yes'
+    }
+  },
   'about-you-first-name': {
     mixin: 'input-text'
   },

--- a/apps/paf/index.js
+++ b/apps/paf/index.js
@@ -632,9 +632,11 @@ module.exports = {
       next: '/other-info-description',
     },
     '/other-info-description': {
+      fields: ['other-info-description'],
       next: '/other-info-another-crime'
     },
     '/other-info-another-crime': {
+      fields: ['other-info-another-crime', 'other-info-another-crime-description'],
       next: '/other-info-file-upload'
     },
     '/other-info-file-upload': {

--- a/apps/paf/sections/summary-data-sections.js
+++ b/apps/paf/sections/summary-data-sections.js
@@ -214,6 +214,11 @@ module.exports = {
     'another-company',
     'another-company-yes'
   ],
+  'other-info': [
+    'other-info-description',
+    'other-info-another-crime',
+    'other-info-another-crime-description'
+  ],
   'about-you': [
     'how-did-you-find-out-about-the-crime',
     'does-anyone-else-know',

--- a/apps/paf/translations/src/en/fields.json
+++ b/apps/paf/translations/src/en/fields.json
@@ -1225,6 +1225,24 @@
     "label": "Does anyone else know about the crime?",
     "hint": " "
   },
+  "other-info-description": {
+    "label": "Please tell us anything else about the crime that you think we should know."
+  },
+  "other-info-another-crime": {
+    "legend": "Do you want to report another crime by the same person or business?",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+  "other-info-another-crime-description": {
+    "label": "Another crime",
+    "hint": "Please enter details of the crime"
+  },
   "have-you-reported-before": {
     "label": "Have you reported the crime before?",
     "hint": " "

--- a/apps/paf/translations/src/en/pages.json
+++ b/apps/paf/translations/src/en/pages.json
@@ -120,10 +120,7 @@
     "header": "Company owner"
   },
   "other-info-description": {
-    "header": "Other information - TO DO"
-  },
-  "other-info-another-crime": {
-    "header": "Do you want to report another crime by the same person or business? - TO DO"
+    "header": "Other information"
   },
   "other-info-file-upload": {
     "header": "Please attach any documents which may help us investigate this crime - TO DO"
@@ -194,47 +191,53 @@
       "organisation-another-company": {
         "header": "The Organisation - Another Company"
       },
+      "other-info": {
+        "header": "Other Information"
+      },
       "about-you": {
         "header": "About you"
       }
     },
-  "fields": {
-    "when-will-crime-happen-more-info": {
-      "label": "More information about when the crime is happening"
-    },
-    "crime-car-group": {
-      "label": "Car type"
-    },
-    "crime-hgv-group": {
-      "label": "HGV type"
-    },
-    "crime-lorry-group": {
-      "label": "Lorry type"
-    },
-    "crime-van-group": {
-      "label": "Van type"
-    },
-    "crime-carrier-group": {
-      "label": "Carrier type"
-    },
-    "crime-general-cargo-group": {
-      "label": "General cargo type"
-    },
-    "crime-vessel-group": {
-      "label": "Vessel type"
-    },
-    "report-person-transport-car-group": {
-      "label": "Car type"
-    },
-    "report-person-transport-hgv-group": {
-      "label": "HGV type"
-    },
-    "report-person-transport-lorry-group": {
-      "label": "Lorry type"
-    },
-    "report-person-transport-van-group": {
-      "label": "Van type"
+    "fields": {
+      "when-will-crime-happen-more-info": {
+        "label": "More information about when the crime is happening"
+      },
+      "crime-car-group": {
+        "label": "Car type"
+      },
+      "crime-hgv-group": {
+        "label": "HGV type"
+      },
+      "crime-lorry-group": {
+        "label": "Lorry type"
+      },
+      "crime-van-group": {
+        "label": "Van type"
+      },
+      "crime-carrier-group": {
+        "label": "Carrier type"
+      },
+      "crime-general-cargo-group": {
+        "label": "General cargo type"
+      },
+      "crime-vessel-group": {
+        "label": "Vessel type"
+      },
+      "report-person-transport-car-group": {
+        "label": "Car type"
+      },
+      "report-person-transport-hgv-group": {
+        "label": "HGV type"
+      },
+      "report-person-transport-lorry-group": {
+        "label": "Lorry type"
+      },
+      "report-person-transport-van-group": {
+        "label": "Van type"
+      },
+      "other-info-another-crime-description": {
+        "label": "Another crime details"
+      }
     }
-  }
   }
 }

--- a/test/_unit/sections/summary-data-sections.spec.js
+++ b/test/_unit/sections/summary-data-sections.spec.js
@@ -324,6 +324,39 @@ describe('PAF Summary Data Sections', () => {
       const result = areOrderedEqual(sectionFields, expectedFields);
       expect(result).to.be.true;
     });
+
+    it('should check expected fields in other-info section', () => {
+      const sectionFields = mappedSections['other-info'];
+      const expectedFields = [
+        'other-info-description',
+        'other-info-another-crime',
+        'other-info-another-crime-description'
+      ];
+      const result = areOrderedEqual(sectionFields, expectedFields);
+      expect(result).to.be.true;
+    });
+
+    it('should check expected fields in about-you section', () => {
+      const sectionFields = mappedSections['about-you'];
+      const expectedFields = [
+        'how-did-you-find-out-about-the-crime',
+        'does-anyone-else-know',
+        'have-you-reported-before',
+        'how-do-you-know-the-person',
+        'can-use-info-without-risk',
+        'about-you-first-name',
+        'about-you-family-name',
+        'about-you-dob',
+        'about-you-nationality',
+        'about-you-gender',
+        'about-you-contact',
+        'are-you-eighteen',
+        'contact-number',
+        'when-to-contact'
+      ];
+      const result = areOrderedEqual(sectionFields, expectedFields);
+      expect(result).to.be.true;
+    });
   });
 
   describe('Sections and Fields', () => {
@@ -458,6 +491,13 @@ describe('PAF Summary Data Sections', () => {
         Object.keys(fields),
         mappedSections['organisation-another-company'])
       ).to.be.true;
+    });
+    
+    it('other-info', () => {
+      mappedSections['other-info'].every(i => {
+        const item = i.field || i;
+        return Object.keys(fields).includes(item);
+      });
     });
   });
 });


### PR DESCRIPTION
## What
- Add pages for other info section
- Add relevant tests

## Why
- Part of PAF form

## Testing
- Test passing  locally