### PR TITLE
PAF-39: add navigation design

### DIFF
--- a/apps/paf/behaviours/set-navigation-section.js
+++ b/apps/paf/behaviours/set-navigation-section.js
@@ -1,0 +1,127 @@
+module.exports = superclass => class extends superclass {
+  configure(req, res, next) {
+    // Person section - set next property for preceeding pages and set backlink
+    if (req.query.section === 'person') {
+      req.form.options.steps['/crime-location'].next = '/report-person'
+      req.form.options.steps['/crime-another-location'].next = '/report-person'
+      res.locals.backLink = 'crime-type'
+    }
+    if (req.form.options.route === '/crime-location' || req.form.options.route === '/crime-another-location') {
+      req.form.options.next = '/report-person'
+    }
+    // Add report person page backlink
+    if (req.form.options.route === '/report-person') {
+      if (req.sessionModel.attributes.steps.includes('/crime-location')) {
+        req.form.options.steps['/report-person'].backLink = 'crime-location'
+        res.locals.backLink = 'crime-location'
+      } else if (req.sessionModel.attributes.steps.includes('/crime-another-location')) {
+        req.form.options.steps['/report-person'].backLink = 'crime-another-location'
+        res.locals.backLink = 'crime-another-location'
+      } else {
+        res.locals.backLink = 'crime-type'
+      }
+    }
+
+
+    // Organisation section - set next property for preceeding pages and set backlink
+    if (req.query.section === 'organisation') {
+      req.form.options.steps['/report-person'].next = '/report-organisation'
+      req.form.options.steps['/has-additionalPerson'].next = '/report-organisation'
+      req.form.options.steps['/person-details'].next = '/report-organisation'
+      res.locals.backLink = 'report-person'
+    }
+    if (req.form.options.route === '/report-person' || req.form.options.route === '/has-additionalPerson' || req.form.options.route === '/person-details') {
+      req.form.options.next = '/report-organisation'
+    }
+    // Add report organisation page backlink
+    if (req.form.options.route === '/report-organisation') {
+      if (req.sessionModel.attributes.steps.includes('/has-additionalPerson') && !req.sessionModel.attributes.steps.includes('/person-details')) {
+        req.form.options.steps['/report-organisation'].backLink = 'has-additionalPerson'
+        res.locals.backLink = 'has-additionalPerson'
+      } else if (req.sessionModel.attributes.steps.includes('/person-details')) {
+        req.form.options.steps['/report-organisation'].backLink = 'person-details'
+        res.locals.backLink = 'person-details'
+      } else {
+        req.form.options.steps['/report-organisation'].backLink = 'report-person'
+        res.locals.backLink = 'report-person'
+      }
+    }
+
+
+    // Other Info section - set next property for preceeding pages and set backlink
+    if (req.query.section === 'other-info') {
+      req.form.options.steps['/report-organisation'].next = '/other-info-description'
+      req.form.options.steps['/another-company'].next = '/other-info-description'
+      res.locals.backLink = 'report-organisation'
+    }
+    if (req.form.options.route === '/report-organisation' || req.form.options.route === '/another-company') {
+      req.form.options.next = '/other-info-description'
+    }
+    // Add other info page backlink
+    if (req.form.options.route === '/other-info-description') {
+      if (req.sessionModel.attributes.steps.includes('/another-company')) {
+        req.form.options.steps['/other-info-description'].backLink = 'another-company'
+        res.locals.backLink = 'another-company'
+      }
+      else {
+        req.form.options.steps['/other-info-description'].backLink = 'report-organisation'
+        res.locals.backLink = 'report-organisation'
+      }
+    }
+
+
+    // About You section - set next property for preceeding pages and set backlink
+    if (req.query.section === 'about-you') {
+      req.form.options.steps['/other-info-file-upload'].next = '/about-you'
+      res.locals.backLink = 'other-info-description'
+    }
+    if (req.form.options.route === '/other-info-file-upload') {
+      req.form.options.next = '/about-you'
+    }
+    // Add about you page backlink
+    if (req.form.options.route === '/about-you') {
+      if (req.sessionModel.attributes.steps.includes('/other-info-file-upload')) {
+        req.form.options.steps['/about-you'].backLink = 'other-info-file-upload'
+        res.locals.backLink = 'other-info-file-upload'
+      }
+    }
+
+
+    // Check Answers section - set next property for preceeding pages and set backlink
+    if (req.query.section === 'check-answers') {
+      req.form.options.steps['/about-you-contact'].next = '/confirm'
+      req.form.options.steps['/are-you-eighteen'].next = '/confirm'
+      res.locals.backLink = 'about-you'
+    }
+    if (req.form.options.route === '/about-you-contact' || req.form.options.route === '/are-you-eighteen') {
+      req.form.options.next = '/confirm'
+    }
+    // Add check answers page backlink
+    if (req.form.options.route === '/confirm') {
+      if (req.sessionModel.attributes.steps.includes('/are-you-eighteen')) {
+        req.form.options.steps['/confirm'].backLink = 'are-you-eighteen'
+        res.locals.backLink = 'are-you-eighteen'
+      } else if (req.sessionModel.attributes.steps.includes('/about-you-contact')) {
+        req.form.options.steps['/confirm'].backLink = 'about-you-contact'
+        res.locals.backLink = 'about-you-contact'
+      }
+    }
+    next();
+  }
+
+  locals(req, res) {
+    const locals = super.locals(req, res);
+    const crimeType = req.sessionModel.get('crime-type');
+    const immmigrationCrime = req.sessionModel.get('immigration-crime-group');
+    const smugglingCrime = req.sessionModel.get('smuggling-crime-group');
+    const crimeChildren = req.sessionModel.get('crime-children');
+
+    // enable section links once required fields have been completed
+    if (crimeType && (immmigrationCrime || smugglingCrime) && crimeChildren) {
+      locals.enableSection = true;
+      return locals;
+    }
+
+    return locals;
+  }
+}

--- a/apps/paf/index.js
+++ b/apps/paf/index.js
@@ -15,6 +15,7 @@ module.exports = {
         'immigration-crime-group',
         'smuggling-crime-group'
       ],
+      backLink: '/start',
       next: '/crime-children'
     },
     '/crime-children': {
@@ -229,7 +230,6 @@ module.exports = {
         'crime-location-address-county',
         'crime-location-address-postcode',
         'crime-location-phone'],
-      next: '/report-person',
       forks: [{
         target: '/crime-another-location',
         condition: {
@@ -248,11 +248,9 @@ module.exports = {
         'crime-another-location-address-postcode',
         'crime-another-location-phone'
       ],
-      next: '/report-person'
     },
     '/report-person': {
       fields: ['report-person'],
-      next: '/report-organisation',
       forks: [{
         target: '/report-person-name',
         condition: {
@@ -510,7 +508,6 @@ module.exports = {
     },
     '/has-additionalPerson': {
       fields: ['hasAdditionalPerson'],
-      next: '/report-organisation',
       forks: [{
         target: '/person-details',
         condition: {
@@ -589,12 +586,10 @@ module.exports = {
       addStep: ['add-person'],
       addAnotherLinkText: 'person',
       template: 'add-another',
-      next: '/report-organisation',
       continueOnEdit: true
     },
     '/report-organisation': {
       fields: ['report-organisation'],
-      next: '/other-info-description',
       forks: [{
         target: '/company-name',
         condition: {
@@ -629,7 +624,6 @@ module.exports = {
     },
     '/another-company': {
       fields: ['another-company', 'another-company-yes'],
-      next: '/other-info-description',
     },
     '/other-info-description': {
       fields: ['other-info-description'],
@@ -640,7 +634,6 @@ module.exports = {
       next: '/other-info-file-upload'
     },
     '/other-info-file-upload': {
-      next: '/about-you'
     },
     '/about-you': {
       fields: ['how-did-you-find-out-about-the-crime'],
@@ -683,7 +676,6 @@ module.exports = {
     },
     '/about-you-contact': {
       fields: ['about-you-contact'],
-      next: '/confirm',
       forks: [{
         target: '/are-you-eighteen',
         condition: {
@@ -693,8 +685,7 @@ module.exports = {
       }]
     },
     '/are-you-eighteen': {
-      fields: ['are-you-eighteen','contact-number','when-to-contact'],
-      next: '/confirm'
+      fields: ['are-you-eighteen','contact-number','when-to-contact']
     },
     '/confirm': {
       behaviours: [SummaryPageBehaviour, personNumber],

--- a/apps/paf/views/layout.html
+++ b/apps/paf/views/layout.html
@@ -1,0 +1,62 @@
+{{<govuk-template}}
+  {{$head}}
+    {{> partials-head}}
+  {{/head}}
+  {{$pageTitle}}
+    {{#errorlist.length}}{{#t}}errorlist.prefix{{/t}}{{/errorlist.length}}{{$header}}{{/header}} &ndash; GOV.UK
+  {{/pageTitle}}
+  {{$bodyStart}}
+    <a href="#{{#skipToMain}}{{skipToMain}}{{/skipToMain}}{{^skipToMain}}main-content{{/skipToMain}}" class="govuk-skip-link" id="skip-to-main">Skip to main content</a>
+  {{/bodyStart}}
+  {{$headerClass}}govuk-header{{/headerClass}}
+  {{$insideHeader}}{{/insideHeader}}
+  {{$main}}
+	  <div class="govuk-width-container ">
+		{{#feedbackUrl}}
+			<div class="govuk-phase-banner">
+				<p class="govuk-phase-banner__content">
+				<strong class="govuk-tag govuk-phase-banner__content__tag">{{#t}}journey.phase{{/t}}</strong>
+				<span  class="govuk-phase-banner__text">This is a new service – your <a href="{{feedbackUrl}}{{^feedbackUrl}}https://eforms.homeoffice.gov.uk/outreach/feedback.ofml{{/feedbackUrl}}" class="govuk-link" id="feedback-link" target="_blank">feedback</a> will help us to improve it.</span>
+				</p>
+			</div>
+		{{/feedbackUrl}}      
+      <span id="step">
+        {{> partials-back}} <span>{{$step}}{{/step}}</span>
+      </span>
+	  <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+		  <div class="govuk-grid-row" id="gov-grid-row-content">
+      {{> partials-side-nav}}
+			{{> partials-maincontent-left}}
+		  </div>
+	  </main>
+      {{> partials-continue}}
+      <script type="text/javascript" src="{{assetPath}}/js/bundle.js"></script>
+	  </div>
+  {{/main}}
+  {{$cookieMessage}}
+    {{#gaTagId}}
+      {{> partials-cookie-banner}}
+    {{/gaTagId}}
+    {{^gaTagId}}
+      <p class="no-ga-tag">
+        {{#t}}cookies.banner.message{{/t}}
+        <a href="/cookies">{{#t}}cookies.banner.link{{/t}}</a>
+      </p>
+    {{/gaTagId}}
+  {{/cookieMessage}}
+  {{$footerSupportLinks}}
+    <ul class="govuk-footer__inline-list">
+      {{#footerSupportLinks}}
+        <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="{{path}}">{{#t}}{{property}}{{/t}}</a></li>
+      {{/footerSupportLinks}}
+      {{^footerSupportLinks}}
+        <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="/cookies">{{#t}}base.cookies{{/t}}</a></li>
+        <li class="govuk-footer__inline-list-item"><a  class="govuk-footer__link" href="/terms-and-conditions">{{#t}}base.terms{{/t}}</a></li>
+        <li class="govuk-footer__inline-list-item"><a  class="govuk-footer__link" href="/accessibility">{{#t}}base.accessibility{{/t}}</a></li>
+      {{/footerSupportLinks}}
+    </ul>
+  {{/footerSupportLinks}}
+  {{$bodyEnd}}
+    {{> partials-gatag}}
+  {{/bodyEnd}}
+{{/govuk-template}}

--- a/apps/paf/views/partials/main-content-left.html
+++ b/apps/paf/views/partials/main-content-left.html
@@ -1,0 +1,10 @@
+{{$content-outer}}
+{{$preloader}}{{/preloader}}
+<div class="govuk-grid-column-two-thirds">
+    {{$validationSummary}}{{/validationSummary}}
+    <header>
+      <h1>{{$header}}{{/header}}</h1>
+    </header>
+    {{$content}}{{/content}}
+  </div>
+{{/content-outer}}

--- a/apps/paf/views/partials/side-nav.html
+++ b/apps/paf/views/partials/side-nav.html
@@ -1,0 +1,57 @@
+<div class="govuk-grid-column-one-third">
+  <nav>
+    <ul>
+      <li class="app-navigation__list-item">
+        <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="/"
+          data-topnav="Start">Start</a>
+      </li>
+      <li class="app-navigation__list-item">
+        <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline"
+          href="{{baseUrl}}/crime-type?section=crime" data-topnav="The Crime">The Crime</a>
+      </li>
+      {{#enableSection}}
+      <li class="app-navigation__list-item">
+        <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline"
+          href="{{baseUrl}}/report-person?section=person" data-topnav="The Person">The Person</a>
+      </li>
+      <li class="app-navigation__list-item">
+        <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline"
+          href="{{baseUrl}}/report-organisation?section=organisation" data-topnav="The Organisation">The
+          Organisation</a>
+      </li>
+      <li class="app-navigation__list-item">
+        <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline"
+          href="{{baseUrl}}/other-info-description?section=other-info" data-topnav="Other Info">Other Information</a>
+      </li>
+      <li class="app-navigation__list-item">
+        <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline"
+          href="{{baseUrl}}/about-you?section=about-you" data-topnav="About You">About You</a>
+      </li>
+      <li class="app-navigation__list-item">
+        <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline"
+          href="{{baseUrl}}/confirm?section=check-answers" data-topnav="Check Your Answers">Check
+          Your Answers</a>
+      </li>
+      {{/enableSection}}
+      {{^enableSection}}
+      <li class="app-navigation__list-item">
+        <a role="link" class="govuk-link--no-visited-state govuk-link--no-underline" aria-disabled="true">The Person</a>
+      </li>
+      <li class="app-navigation__list-item">
+        <a role="link" class="govuk-link--no-visited-state govuk-link--no-underline" aria-disabled="true">The
+          Organisation</a>
+      </li>
+      <li class="app-navigation__list-item">
+        <a role="link" class="govuk-link--no-visited-state govuk-link--no-underline" aria-disabled="true">Other Info</a>
+      </li>
+      <li class="app-navigation__list-item">
+        <a role="link" class="govuk-link--no-visited-state govuk-link--no-underline" aria-disabled="true">About You</a>
+      </li>
+      <li class="app-navigation__list-item">
+        <a role="link" class="govuk-link--no-visited-state govuk-link--no-underline" aria-disabled="true">Check Your
+          Answers</a>
+      </li>
+    </ul>
+    {{/enableSection}}
+  </nav>
+</div>

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -10,7 +10,7 @@ ul {
   @extend .list-bullet;
 }
 
-a {
+a:link {
   @extend .govuk-link;
 }
 
@@ -44,6 +44,7 @@ a {
 .autocomplete__input--default {
   padding: 5px;
 }
+
 .autocomplete__input--focused {
   outline: 3px solid #fd0;
   outline-offset: 0;
@@ -55,7 +56,7 @@ a {
   cursor: pointer;
 }
 
-.autocomplete__dropdown-arrow-down{
+.autocomplete__dropdown-arrow-down {
   z-index: -1;
   display: inline-block;
   position: absolute;
@@ -106,7 +107,7 @@ a {
   position: relative;
 }
 
-.autocomplete__option > * {
+.autocomplete__option>* {
   pointer-events: none;
 }
 
@@ -149,10 +150,78 @@ a {
 }
 
 @media (min-width: 641px) {
+
   .autocomplete__hint,
   .autocomplete__input,
   .autocomplete__option {
     font-size: 19px;
     line-height: 1.31579;
   }
+}
+
+
+// navigation layout
+$navigation-height: 50px;
+
+.govuk-link:hover {
+  font-family: "GDS Transport", arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-decoration: underline;
+  text-decoration-thickness: max(1px, 0.0625rem);
+  text-underline-offset: 0.1em;
+}
+
+.app-navigation__list {
+  @include govuk-media-query($from: tablet) {
+    margin-top: govuk-spacing(6) * 1.5;
+  }
+
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+
+    ul {
+      margin-top: govuk-spacing(2);
+      border-top: 1px govuk-shade(govuk-colour("light-grey"), 7%) solid;
+    }
+  }
+}
+
+.app-navigation__list-item {
+  @include govuk-font(16);
+
+  border-bottom: 1px govuk-shade(govuk-colour("light-grey"), 7%) solid;
+  display: block;
+  padding: govuk-spacing(2) 0;
+}
+
+
+
+.app-navigation__link {
+  text-decoration: none;
+
+  &:not(:focus):hover {
+    color: #1d70b8;
+    text-decoration-thickness: max(3px, 0.1875rem, 0.12em);
+  }
+
+  // Extend the touch area of the link to the list
+  &:after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+}
+
+.app-navigation__list-item--current .app-navigation__link:hover {
+  text-decoration: none;
+}
+
+#govuk-header {
+  background-color: black;
 }

--- a/hof.settings.json
+++ b/hof.settings.json
@@ -1,6 +1,9 @@
 {
   "appName":"Public Allegations Form",
   "theme": "govUK",
+  "behaviours": [
+    "./apps/paf/behaviours/set-navigation-section"
+  ],
   "routes": [
     "./apps/common",
     "./apps/paf"

--- a/server.js
+++ b/server.js
@@ -5,7 +5,8 @@ let settings = require('./hof.settings');
 const config = require('./config.js');
 
 settings = Object.assign({}, settings, {
-  routes: settings.routes.map(require)
+  routes: settings.routes.map(require),
+  behaviours: settings.behaviours.map(require)
 });
 
 const app = hof(settings);

--- a/test/_unit/behaviours/set-navigation-section.spec.js
+++ b/test/_unit/behaviours/set-navigation-section.spec.js
@@ -1,0 +1,314 @@
+'use strict';
+
+const Controller = require('hof').controller;
+const Behaviour = require('../../../apps/paf/behaviours/set-navigation-section');
+
+describe('apps/paf/behaviours/set-navigation-section', () => {
+  describe('configure', () => {
+    let controller;
+    let req;
+    let res;
+    let sandbox;
+
+    beforeEach(done => {
+
+      req = reqres.req();
+      res = reqres.res();
+      req.sessionModel.attributes.steps = [];
+
+      const GetSectionController = Behaviour(Controller);
+      controller = new GetSectionController({ template: 'index', route: '/index' });
+      controller._configure(req, res, done);
+    });
+
+
+    describe('sets the next page according to the section', () => {
+      beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        req.form.options = {
+          steps: {
+            '/crime-location': {},
+            '/crime-another-location': {},
+            '/report-person': {},
+            '/has-additionalPerson': {},
+            '/person-details': {},
+            '/report-organisation': {},
+            '/another-company': {},
+            '/other-info-file-upload': {},
+            '/about-you-contact': {},
+            '/are-you-eighteen': {},
+          }
+        };
+
+        sandbox.stub(Controller.prototype, 'configure').yieldsAsync();
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it(`the crime-location page has the next page as '/report-person'`, () => {
+        req.query.section = 'person';
+        req.form.options.route = '/crime-location';
+        controller.configure(req, res, () => {
+          const crimeLocationNext = req.form.options.steps['/crime-location'].next;
+          crimeLocationNext.should.deep.equal('/report-person');
+          req.form.options.next.should.deep.equal('/report-person')
+        })
+      });
+
+      it(`the crime-another-location page has the next page as '/report-person'`, () => {
+        req.query.section = 'person';
+        req.form.options.route = '/crime-another-location';
+        controller.configure(req, res, () => {
+          const crimeAnotherLocationNext = req.form.options.steps['/crime-another-location'].next;
+          crimeAnotherLocationNext.should.deep.equal('/report-person');
+          req.form.options.next.should.deep.equal('/report-person')
+        })
+      });
+
+      it(`the report-person page has the next page as '/report-organisation'`, () => {
+        req.query.section = 'organisation';
+        req.form.options.route = '/report-person';
+        controller.configure(req, res, () => {
+          const reportPersonNext = req.form.options.steps['/report-person'].next;
+          reportPersonNext.should.deep.equal('/report-organisation');
+          req.form.options.next.should.deep.equal('/report-organisation')
+        })
+      });
+
+      it(`the has-additionalPerson page has the next page as '/report-organisation'`, () => {
+        req.query.section = 'organisation';
+        req.form.options.route = '/has-additionalPerson';
+        controller.configure(req, res, () => {
+          const hasAdditionalPersonNext = req.form.options.steps['/has-additionalPerson'].next;
+          hasAdditionalPersonNext.should.deep.equal('/report-organisation');
+          req.form.options.next.should.deep.equal('/report-organisation')
+        })
+      });
+
+      it(`the person-details page has the next page as '/report-organisation'`, () => {
+        req.query.section = 'organisation';
+        req.form.options.route = '/person-details';
+        controller.configure(req, res, () => {
+          const personDetailsNext = req.form.options.steps['/person-details'].next
+          personDetailsNext.should.deep.equal('/report-organisation');
+          req.form.options.next.should.deep.equal('/report-organisation')
+        })
+      });
+
+      it(`the report-organisation page has the next page as '/other-info-description'`, () => {
+        req.query.section = 'other-info';
+        req.form.options.route = '/report-organisation';
+        controller.configure(req, res, () => {
+          const reportOrganisationNext = req.form.options.steps['/report-organisation'].next;
+          reportOrganisationNext.should.deep.equal('/other-info-description');
+          req.form.options.next.should.deep.equal('/other-info-description')
+        })
+      });
+
+      it(`the another-company page has the next page as '/other-info-description'`, () => {
+        req.query.section = 'other-info';
+        req.form.options.route = '/another-company';
+        controller.configure(req, res, () => {
+          const anotherCompanyNext = req.form.options.steps['/another-company'].next;
+          anotherCompanyNext.should.deep.equal('/other-info-description');
+          req.form.options.next.should.deep.equal('/other-info-description')
+        })
+      });
+
+      it(`the other-info-file-upload page has the next page as '/about-you'`, () => {
+        req.query.section = 'about-you';
+        req.form.options.route = '/other-info-file-upload';
+        controller.configure(req, res, () => {
+          const otherInfoFileUploadNext = req.form.options.steps['/other-info-file-upload'].next;
+          otherInfoFileUploadNext.should.deep.equal('/about-you');
+          req.form.options.next.should.deep.equal('/about-you')
+        })
+      });
+
+      it(`the about-you-contact page has the next page as '/confirm'`, () => {
+        req.query.section = 'check-answers';
+        req.form.options.route = '/about-you-contact';
+        controller.configure(req, res, () => {
+          const aboutYouContactNext = req.form.options.steps['/about-you-contact'].next;
+          aboutYouContactNext.should.deep.equal('/confirm');
+          req.form.options.next.should.deep.equal('/confirm')
+        })
+      });
+
+      it(`the are-you-eighteen page has the next page as '/confirm'`, () => {
+        req.query.section = 'check-answers';
+        req.form.options.route = '/are-you-eighteen';
+        controller.configure(req, res, () => {
+          const areYouEighteenNext = req.form.options.steps['/are-you-eighteen'].next;
+          areYouEighteenNext.should.deep.equal('/confirm');
+          req.form.options.next.should.deep.equal('/confirm')
+        })
+      });
+    });
+
+    describe('sets the backlink for each section', () => {
+      beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        req.form.options = {
+          steps: {
+            '/crime-location': {},
+            '/crime-another-location': {},
+            '/report-person': {},
+            '/has-additionalPerson': {},
+            '/person-details': {},
+            '/report-organisation': {},
+            '/another-company': {},
+            '/other-info-description': {},
+            '/other-info-file-upload': {},
+            '/about-you': {},
+            '/about-you-contact': {},
+            '/are-you-eighteen': {},
+            '/confirm': {}
+          }
+        };
+
+        sandbox.stub(Controller.prototype, 'configure').yieldsAsync();
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('has the crime-location backlink for the report-person page', () => {
+        req.form.options.route = '/report-person';
+        req.sessionModel.attributes.steps.push('/crime-location');
+        controller.configure(req, res, () => {
+          req.form.options.steps['/report-person'].backLink.should.deep.equal('crime-location');
+          res.locals.backLink.should.deep.equal('crime-location')
+        })
+      });
+
+      it('has the crime-another-location backlink for the report-person page', () => {
+        req.form.options.route = '/report-person';
+        req.sessionModel.attributes.steps.push('/crime-another-location');
+        controller.configure(req, res, () => {
+          req.form.options.steps['/report-person'].backLink.should.deep.equal('crime-another-location');
+          res.locals.backLink.should.deep.equal('crime-another-location');
+        })
+      });
+
+      it('has the report-person backlink for the report-organisation page', () => {
+        req.form.options.route = '/report-organisation';
+        controller.configure(req, res, () => {
+          req.form.options.steps['/report-organisation'].backLink.should.deep.equal('report-person');
+          res.locals.backLink.should.deep.equal('report-person');
+        })
+      });
+
+      it('has the has-additionalPerson backlink for the report-organisation page', () => {
+        req.form.options.route = '/report-organisation';
+        req.sessionModel.attributes.steps.push('/has-additionalPerson');
+        controller.configure(req, res, () => {
+          req.form.options.steps['/report-organisation'].backLink.should.deep.equal('has-additionalPerson');
+          res.locals.backLink.should.deep.equal('has-additionalPerson');
+        })
+      });
+
+      it('has the person-details backlink for the report-organisation page', () => {
+        req.form.options.route = '/report-organisation';
+        req.sessionModel.attributes.steps.push('/person-details');
+        controller.configure(req, res, () => {
+          req.form.options.steps['/report-organisation'].backLink.should.deep.equal('person-details');
+          res.locals.backLink.should.deep.equal('person-details');
+        })
+      });
+
+      it('has the report-organisation backlink for the other-info-description page', () => {
+        req.form.options.route = '/other-info-description'
+        controller.configure(req, res, () => {
+          req.form.options.steps['/other-info-description'].backLink.should.deep.equal('report-organisation');
+          res.locals.backLink.should.deep.equal('report-organisation');
+        })
+      });
+
+      it('has the another-company backlink for the other-info-description page', () => {
+        req.form.options.route = '/other-info-description';
+        req.sessionModel.attributes.steps.push('/another-company');
+        controller.configure(req, res, () => {
+          req.form.options.steps['/other-info-description'].backLink.should.deep.equal('another-company');
+          res.locals.backLink.should.deep.equal('another-company');
+        })
+      });
+
+      it('has the other-info-file-upload backlink for the about-you page', () => {
+        req.form.options.route = '/about-you'
+        req.sessionModel.attributes.steps.push('/other-info-file-upload')
+        controller.configure(req, res, () => {
+          req.form.options.steps['/about-you'].backLink.should.deep.equal('other-info-file-upload');
+          res.locals.backLink.should.deep.equal('other-info-file-upload');
+        })
+      });
+
+      it('has the about-you-contact backlink for the check answers page', () => {
+        req.form.options.route = '/confirm';
+        req.sessionModel.attributes.steps.push('/about-you-contact');
+        controller.configure(req, res, () => {
+          req.form.options.steps['/confirm'].backLink.should.deep.equal('about-you-contact');
+          res.locals.backLink.should.deep.equal('about-you-contact');
+        })
+      });
+
+      it('has the are-you-eighteen backlink for the check answers page', () => {
+        req.form.options.route = '/confirm';
+        req.sessionModel.attributes.steps.push('/are-you-eighteen');
+        controller.configure(req, res, () => {
+          req.form.options.steps['/confirm'].backLink.should.deep.equal('are-you-eighteen');
+          res.locals.backLink.should.deep.equal('are-you-eighteen');
+        })
+      });
+    });
+  });
+
+  describe('locals', () => {
+    let controller;
+    let req;
+    let res;
+
+    beforeEach(done => {
+      req = reqres.req();
+      res = reqres.res();
+      const GetSectionController = Behaviour(Controller);
+      controller = new GetSectionController({ template: 'index', route: '/index' });
+      controller._configure(req, res, done);
+    });
+
+    describe('disables and enables sections links based on whether required crime type and crime children questions have been completed', () => {
+
+      it('locals should not have enableSection property if all required fields not completed', () => {
+        req.sessionModel.set('crime-type', undefined)
+        req.sessionModel.set('immigration-crime-group', undefined)
+        req.sessionModel.set('crime-children', undefined)
+        controller.locals(req, res).should.not.have.property('enableSection')
+      });
+
+      it('locals should not have enableSection property if required crime-type toggle and crime-children fields not completed', () => {
+        req.sessionModel.set('crime-type', 'immigration-crime')
+        req.sessionModel.set('immigration-crime-group', undefined)
+        req.sessionModel.set('crime-children', undefined)
+        controller.locals(req, res).should.not.have.property('enableSection')
+      });
+
+      it('locals should not have enableSection property if required crime-children field not completed', () => {
+        req.sessionModel.set('crime-type', 'immigration-crime')
+        req.sessionModel.set('immigration-crime-group', 'immigration-crime-no-permission')
+        req.sessionModel.set('crime-children', undefined)
+        controller.locals(req, res).should.not.have.property('enableSection')
+      });
+
+      it('locals.enableSection is true if required fields are completed', () => {
+        req.sessionModel.set('crime-type', 'immigration-crime')
+        req.sessionModel.set('immigration-crime-group', 'immigration-crime-no-permission')
+        req.sessionModel.set('crime-children', 'yes')
+        controller.locals(req, res).should.have.property('enableSection')
+          .and.deep.equal(true);
+      });
+    });
+  });
+});

--- a/test/_unit/server.spec.js
+++ b/test/_unit/server.spec.js
@@ -7,6 +7,7 @@ describe('Server.js app file', () => {
   let sendStub;
   let appsCommonStub;
   let appsPafStub;
+  let behavioursSetNavigationSectionStub;
   let req;
   let res;
   let next;
@@ -30,6 +31,7 @@ describe('Server.js app file', () => {
     useStub = sinon.stub();
     appsCommonStub = sinon.stub();
     appsPafStub = sinon.stub();
+    behavioursSetNavigationSectionStub = sinon.stub();
 
     useStub.onCall(0).yields(req, res, next);
     useStub.onCall(1).yields(req, res);
@@ -39,6 +41,7 @@ describe('Server.js app file', () => {
       hof: hofStub,
       './apps/common': appsCommonStub,
       './apps/paf': appsPafStub,
+      './apps/paf/behaviours/set-navigation-section': behavioursSetNavigationSectionStub,
       './config': { env: 'test' }
     });
   });
@@ -52,6 +55,7 @@ describe('Server.js app file', () => {
           appsCommonStub,
           appsPafStub
         ],
+        behaviours: [ behavioursSetNavigationSectionStub],
         session: { name: 'paf.hof.sid' }
       });
     });


### PR DESCRIPTION
## What
- Create get-section behaviour to configure navigation menu links
- Remove next property from index.js for pages preceeding section pages as they were preventing this pages from being reached (the next property for these pages have now been configured in the get-section behaviour)
- Add views for layout, side-nav and main content
- Add css for side navigation
- Amend css for links so disabled links do not have govuk-link class
- Add get-section behaviour to hof.settings so it is applied across all pages 
- Add behaviours in hof.settings to server.js
- Add relevant tests

## Why
- Part of PAF form

## Testing
- tests passing locally