### PR TITLE
PAF-44: PAF time field

### DIFF
--- a/apps/paf/behaviours/time-formatter.js
+++ b/apps/paf/behaviours/time-formatter.js
@@ -1,0 +1,56 @@
+/* eslint-disable  max-len */
+const _ = require('lodash');
+
+module.exports = superclass => class extends superclass {
+  configure(req, res, next) {
+    // preprend '0' if number is only a single digit
+    const pad = num => num !== '' && num.length < 2 ? `0${num}` : num;
+
+    if (req.sessionModel.get('time-crime-will-happen-hour')) {
+      req.sessionModel.set('time-crime-will-happen-hour', pad(req.sessionModel.get('time-crime-will-happen-hour')));
+    }
+    if (req.sessionModel.get('time-crime-will-happen-minute')) {
+      req.sessionModel.set('time-crime-will-happen-minute', pad(req.sessionModel.get('time-crime-will-happen-minute')));
+    }
+    // sets minutes to 00 if the hour field has been completed but the minute field left blank
+    if (req.sessionModel.get('time-crime-will-happen-hour') && req.sessionModel.get('time-crime-will-happen-minute') === '') {
+      req.sessionModel.set('time-crime-will-happen-minute', '00');
+    }
+
+    if (req.sessionModel.get('time-crime-will-happen-hour') && req.sessionModel.get('time-crime-will-happen-minute')) {
+      const time = req.sessionModel.get('time-crime-will-happen-hour').concat(' : ', req.sessionModel.get('time-crime-will-happen-minute'));
+      if (req.sessionModel.get('time-crime-will-happen-hour') < 12) {
+        req.sessionModel.set('time-crime-will-happen', time + ' am');
+      } else {
+        req.sessionModel.set('time-crime-will-happen', time + ' pm');
+      }
+    } else {
+      req.sessionModel.unset('time-crime-will-happen');
+    }
+
+    return super.configure(req, res, next);
+  }
+
+  locals(req, res) {
+    const locals = super.locals(req, res);
+    // set change link for for time-crime-will-happen field
+    if (locals.route === 'confirm') {
+      _.forEach(locals.rows, fields => {
+        locals.rows = locals.rows.map(row => {
+          if (row.section === 'The Crime - Duration') {
+            _.forEach(fields, sectionFields => {
+              _.forEach(sectionFields, field => {
+                if (field.field === 'time-crime-will-happen') {
+                  field.changeLink = '/paf/date-time-crime-will-happen/edit#time-crime-will-happen-hour';
+                }
+              });
+            });
+            return row;
+          }
+          return row;
+        });
+      });
+    }
+    return locals;
+  }
+};

--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -131,6 +131,18 @@ module.exports = {
   'date-crime-will-happen': dateComponent('date-crime-will-happen', {
     mixin: 'input-date'
   }),
+  'time-crime-will-happen-hour': {
+    mixin: 'input-text',
+    className: ['govuk-input', 'govuk-date-input__input', 'govuk-input--width-2'],
+    attributes: [{ attribute: 'maxlength', value: '2' }],
+    validate: ['numeric', { type: 'min', arguments: 0}, { type: 'max', arguments: 23 }]
+  },
+  'time-crime-will-happen-minute': {
+    mixin: 'input-text',
+    className: ['govuk-input', 'govuk-date-input__input', 'govuk-input--width-2'],
+    attributes: [{ attribute: 'maxlength', value: '2' }],
+    validate: ['numeric', { type: 'min', arguments: 0}, { type: 'max', arguments: 59 }]
+  },
   'time-crime-will-happen': {
     mixin: 'input-text'
   },

--- a/apps/paf/index.js
+++ b/apps/paf/index.js
@@ -13,6 +13,7 @@ const addressFormatter = require('./behaviours/address-formatter');
 const additionalPersonFormatter = require('./behaviours/additional-person-formatter');
 const vehicleToggleFormatter = require('./behaviours/vehicle-toggle-formatter');
 const SendToSQS = require('./behaviours/send-to-sqs');
+const timeFormatter = require('./behaviours/time-formatter');
 
 module.exports = {
   name: 'paf',
@@ -58,7 +59,7 @@ module.exports = {
       }]
     },
     '/date-time-crime-will-happen': {
-      fields: ['date-crime-will-happen', 'time-crime-will-happen'],
+      fields: ['date-crime-will-happen', 'time-crime-will-happen-hour', 'time-crime-will-happen-minute'],
       next: '/when-will-crime-happen-more-info'
     },
     '/when-will-crime-happen-more-info': {
@@ -769,7 +770,7 @@ module.exports = {
       fields: ['are-you-eighteen', 'contact-number', 'when-to-contact']
     },
     '/confirm': {
-      behaviours: [SummaryPageBehaviour, personNumber],
+      behaviours: [SummaryPageBehaviour, personNumber, timeFormatter],
       sections: require('./sections/summary-data-sections'),
       next: '/declaration'
     },

--- a/apps/paf/translations/src/en/fields.json
+++ b/apps/paf/translations/src/en/fields.json
@@ -128,8 +128,11 @@
   "date-crime-will-happen": {
     "label": "Date"
   },
-  "time-crime-will-happen": {
-    "label": "Time"
+  "time-crime-will-happen-hour": {
+    "label": "Hour"
+  },
+  "time-crime-will-happen-minute": {
+    "label": "Minute"
   },
   "crime-transport": {
     "legend": "Does the crime involve any vehicles, transport or travel?",

--- a/apps/paf/translations/src/en/pages.json
+++ b/apps/paf/translations/src/en/pages.json
@@ -206,6 +206,9 @@
       }
     },
     "fields": {
+      "time-crime-will-happen": {
+        "label": "Time"
+      },
       "when-will-crime-happen-more-info": {
         "label": "More information about when the crime is happening"
       },

--- a/apps/paf/translations/src/en/validation.json
+++ b/apps/paf/translations/src/en/validation.json
@@ -185,6 +185,19 @@
     "url": "Enter a website address in the correct format, like www.example.com",
     "maxlength": "You can't use more than {{maxlength}} characters for your answer"
   },
+  "time-crime-will-happen-hour": {
+    "numeric": "Please enter a valid time in digits",
+    "min": "Please enter a number from 0 to 23",
+    "max": "Please enter a number from 0 to 23"
+  },
+  "time-crime-will-happen-minute": {
+    "numeric": "Please enter a valid time in digits",
+    "min": "Please enter a number from 0 to 59",
+    "max": "Please enter a number from 0 to 59"
+  },
+  "company-postcode": {
+    "postcode": "Enter a real postcode"
+  },
   "company-email": {
     "email": "There is a problem with the email you have entered. Please ensure it is not longer than 100 characters, it does not include invalid characters and it is in the format of <name>@<domain name> e.g. name@email.co.uk. If you do not know this information, please leave this field blank."
   },

--- a/apps/paf/views/date-time-crime-will-happen.html
+++ b/apps/paf/views/date-time-crime-will-happen.html
@@ -1,0 +1,24 @@
+{{<partials-page}} 
+  {{$page-content}}
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset" role="group" aria-describedby="time-crime-will-happen-hint">
+        <legend><strong>Time</strong></legend>
+        <div id="time-crime-will-happen-hint" class="govuk-hint">
+          Please enter as a 24-hour clock. For example, midnight would be 00 00.
+        </div>
+        <div class="time-input__item">
+          {{#input-text}}time-crime-will-happen-hour{{/input-text}}
+        </div>
+        <div class="time-input__item">
+          {{#input-text}}time-crime-will-happen-minute{{/input-text}}
+        </div>
+      </fieldset>
+    </div>
+    <div>
+      <legend><strong>Date</strong></legend>
+      {{#input-date}}date-crime-will-happen{{/input-date}}
+    </div>
+    
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -231,3 +231,18 @@ pre.looped-records {
   word-break: break-all;
 }
 
+.time-input__item {
+  display: inline-block;
+  margin-right: 20px;
+  margin-bottom: 0;
+}
+.time-input__item  .govuk-input__wrapper {
+display: block;
+}
+.time-input__item .govuk-form-group--error {
+  border-left: none;
+  padding-left: 0px;
+}
+.time-input__item .govuk-error-message {
+  display: none;
+}

--- a/hof.settings.json
+++ b/hof.settings.json
@@ -2,7 +2,8 @@
   "appName":"Public Allegations Form",
   "theme": "govUK",
   "behaviours": [
-    "./apps/paf/behaviours/set-navigation-section"
+    "./apps/paf/behaviours/set-navigation-section",
+    "./apps/paf/behaviours/time-formatter"
   ],
   "routes": [
     "./apps/common",

--- a/test/_unit/behaviours/time-formatter.spec.js
+++ b/test/_unit/behaviours/time-formatter.spec.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const Behaviour = require('../../../apps/paf/behaviours/time-formatter');
+
+describe("apps/paf 'time-formatter' behaviour ", () => {
+  class Base {
+    constructor() {}
+    configure() {}
+  }
+
+  let req;
+  let res;
+  let instance;
+  const next = 'foo';
+
+  beforeEach(() => {
+    req = reqres.req();
+    res = reqres.res();
+  });
+  describe("The 'configure' method ", () => {
+    beforeEach(() => {
+      sinon.stub(Base.prototype, 'configure').returns(req, res, next);
+      instance = new (Behaviour(Base))();
+    });
+
+    it('should configure the time format', () => {
+      req.sessionModel.set('time-crime-will-happen-hour', '11');
+      req.sessionModel.set('time-crime-will-happen-minute', '15');
+
+      instance.configure(req, res, next);
+      expect(req.sessionModel.get('time-crime-will-happen')).to.equal('11 : 15 am');
+    });
+
+    it('should configures the am/pm suffix', () => {
+      req.sessionModel.set('time-crime-will-happen-hour', '05');
+      req.sessionModel.set('time-crime-will-happen-minute', '15');
+
+      instance.configure(req, res, next);
+      expect(req.sessionModel.get('time-crime-will-happen')).to.equal('05 : 15 am');
+
+      req.sessionModel.set('time-crime-will-happen-hour', '13');
+
+      instance.configure(req, res, next);
+      expect(req.sessionModel.get('time-crime-will-happen')).to.equal('13 : 15 pm');
+    });
+
+    afterEach(() => {
+      Base.prototype.configure.restore();
+    });
+  });
+});

--- a/test/_unit/server.spec.js
+++ b/test/_unit/server.spec.js
@@ -6,6 +6,7 @@ describe('Server.js app file', () => {
   let appsCommonStub;
   let appsPafStub;
   let behavioursSetNavigationSectionStub;
+  let behavioursTimeFormatterStub;
   let req;
   let res;
   let next;
@@ -30,6 +31,7 @@ describe('Server.js app file', () => {
     appsCommonStub = sinon.stub();
     appsPafStub = sinon.stub();
     behavioursSetNavigationSectionStub = sinon.stub();
+    behavioursTimeFormatterStub = sinon.stub();
 
     useStub.onCall(0).yields(req, res, next);
     useStub.onCall(1).yields(req, res);
@@ -40,6 +42,7 @@ describe('Server.js app file', () => {
       './apps/common': appsCommonStub,
       './apps/paf': appsPafStub,
       './apps/paf/behaviours/set-navigation-section': behavioursSetNavigationSectionStub,
+      './apps/paf/behaviours/time-formatter': behavioursTimeFormatterStub,
       './config': { env: 'test' }
     });
   });
@@ -53,7 +56,7 @@ describe('Server.js app file', () => {
           appsCommonStub,
           appsPafStub
         ],
-        behaviours: [ behavioursSetNavigationSectionStub],
+        behaviours: [ behavioursSetNavigationSectionStub, behavioursTimeFormatterStub ],
         session: { name: 'paf.hof.sid' }
       });
     });


### PR DESCRIPTION
## What?
- Add a custom time field view for PAF. - [PAF-44](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-44)

## Why?
Part of PAF app

## How?
- add time fields for 'hour' and 'minute'
- add custom time fields in view
- add change link to time field on check answers page
- add styling to time fields
- add behaviour to format time
- add tests for time formatter behaviour

## Testing?
Tests running locally

## Screenshots (optional)
<img width="1049" alt="Time field" src="https://github.com/UKHomeOffice/paf/assets/43888758/f8d15abd-0d38-458b-a69d-2b8a8b3d80f4">

<img width="1057" alt="Morning time on check answers page" src="https://github.com/UKHomeOffice/paf/assets/43888758/782082a1-38ea-41cc-b667-6a1ec76f1ccf">

<img width="1108" alt="Afternoon time on check answers page" src="https://github.com/UKHomeOffice/paf/assets/43888758/cbcd1720-2dbd-49d9-9260-2f7c36281ec5">

<img width="838" alt="time field Validations" src="https://github.com/UKHomeOffice/paf/assets/43888758/68a35e57-eafe-4af6-84d7-860885dbb05c">


## Anything Else? (optional)
