### PR TITLE
fix about-you navigation bug caused by merge conflict

### DIFF
--- a/apps/paf/index.js
+++ b/apps/paf/index.js
@@ -678,8 +678,7 @@ module.exports = {
           }
           return false;
         }
-      }],
-      next: '/about-you'
+      }]
     },
     '/add-other-info-file-upload': {
       template: 'list-add-looped-files',
@@ -693,7 +692,6 @@ module.exports = {
         combineValuesToSingleField: 'record',
         returnTo: '/other-info-file-upload'
       }), removeImage, limitDocs],
-      next: '/about-you',
       locals: {
         section: 'other-info-file-upload'
       }


### PR DESCRIPTION
## What?
- Fix bug where 'about you' link in nav bar was not working
## Why?
- 'About you' link in navbar was not working after merge reintroduced old code not needed for nav bar
## How?
- amended index.js and removed `next: 'about-you` property that was causing the issue.
## Testing?
- tests passing locally
## Screenshots (optional)
## Anything Else? (optional)