### PR TITLE
Format vehicle-type, boat-type, report-person-transport radio toggle values for mapping

### DIFF
--- a/apps/paf/behaviours/vehicle-toggle-formatter.js
+++ b/apps/paf/behaviours/vehicle-toggle-formatter.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = superclass => class extends superclass {
+  process(req, res, next) {
+    if (req.sessionModel.get('crime-car-group')) {
+      req.sessionModel.set('vehicle-type', req.sessionModel.get('crime-car-group'));
+    }
+    if (req.sessionModel.get('crime-hgv-group')) {
+      req.sessionModel.set('vehicle-type', req.sessionModel.get('crime-hgv-group'));
+    }
+    if (req.sessionModel.get('crime-lorry-group')) {
+      req.sessionModel.set('vehicle-type', req.sessionModel.get('crime-lorry-group'));
+    }
+    if (req.sessionModel.get('crime-van-group')) {
+      req.sessionModel.set('vehicle-type', req.sessionModel.get('crime-van-group'));
+    }
+    if (req.sessionModel.get('crime-carrier-group')) {
+      req.sessionModel.set('boat-type', req.sessionModel.get('crime-carrier-group'));
+    }
+    if (req.sessionModel.get('crime-general-cargo-group')) {
+      req.sessionModel.set('boat-type', req.sessionModel.get('crime-general-cargo-group'));
+    }
+    if (req.sessionModel.get('crime-vessel-group')) {
+      req.sessionModel.set('boat-type', req.sessionModel.get('crime-vessel-group'));
+    }
+    if (req.sessionModel.get('report-person-transport-car-group')) {
+      req.sessionModel.set('report-person-transport-type', req.sessionModel.get('report-person-transport-car-group'));
+    }
+    if (req.sessionModel.get('report-person-transport-hgv-group')) {
+      req.sessionModel.set('report-person-transport-type', req.sessionModel.get('report-person-transport-hgv-group'));
+    }
+    if (req.sessionModel.get('report-person-transport-lorry-group')) {
+      req.sessionModel.set('report-person-transport-type', req.sessionModel.get('report-person-transport-lorry-group'));
+    }
+    if (req.sessionModel.get('report-person-transport-van-group')) {
+      req.sessionModel.set('report-person-transport-type', req.sessionModel.get('report-person-transport-van-group'));
+    }
+    return super.process(req, res, next);
+  }
+};

--- a/apps/paf/index.js
+++ b/apps/paf/index.js
@@ -11,6 +11,7 @@ const limitPerson = require('./behaviours/limit-person');
 const personNumber = require('./behaviours/person-number');
 const addressFormatter = require('./behaviours/address-formatter');
 const additionalPersonFormatter = require('./behaviours/additional-person-formatter');
+const vehicleToggleFormatter = require('./behaviours/vehicle-toggle-formatter');
 const SendToSQS = require('./behaviours/send-to-sqs');
 
 module.exports = {
@@ -755,12 +756,12 @@ module.exports = {
       fields: ['are-you-eighteen', 'contact-number', 'when-to-contact']
     },
     '/confirm': {
-      behaviours: [addressFormatter, additionalPersonFormatter, SummaryPageBehaviour, personNumber],
+      behaviours: [SummaryPageBehaviour, personNumber],
       sections: require('./sections/summary-data-sections'),
       next: '/declaration'
     },
     '/declaration': {
-      behaviours: ['complete', SendToSQS],
+      behaviours: ['complete', addressFormatter, additionalPersonFormatter,vehicleToggleFormatter, SendToSQS],
       next: '/confirmation'
     },
     '/confirmation': {

--- a/apps/paf/views/partials/crime-van-group.html
+++ b/apps/paf/views/partials/crime-van-group.html
@@ -20,8 +20,8 @@
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="crime-van-group" id="crime-van-group-7.5-tonne-van"  value="7.5-tonne-van">
-        <label class="govuk-label govuk-radios__label" for="crime-van-group-7.5-tonne-van">
+        <input class="govuk-radios__input"  type="radio" name="crime-van-group" id="crime-van-group-seven-point-five-tonne-van"  value="seven-point-five-tonne-van">
+        <label class="govuk-label govuk-radios__label" for="crime-van-group-seven-point-five-tonne-van">
           {{#t}}fields.crime-van-group.options.seven-point-five-tonne-van{{/t}}
         </label>
       </div>

--- a/apps/paf/views/partials/report-person-transport-van-group.html
+++ b/apps/paf/views/partials/report-person-transport-van-group.html
@@ -20,8 +20,8 @@
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="report-person-transport-van-group" id="report-person-transport-van-group-7.5-tonne-van"  value="7.5-tonne-van">
-        <label class="govuk-label govuk-radios__label" for="report-person-transport-van-group-7.5-tonne-van">
+        <input class="govuk-radios__input"  type="radio" name="report-person-transport-van-group" id="report-person-transport-van-group-seven-point-five-tonne-van"  value="seven-point-five-tonne-van">
+        <label class="govuk-label govuk-radios__label" for="report-person-transport-van-group-seven-point-five-tonne-van">
           {{#t}}fields.report-person-transport-van-group.options.seven-point-five-tonne-van{{/t}}
         </label>
       </div>

--- a/lib/ims-hof-fields-map.json
+++ b/lib/ims-hof-fields-map.json
@@ -1,6 +1,10 @@
 {
     "Fields": [
         {
+        "IMS": "lsvehicle",
+        "HOF": "vehicle-type"
+        },
+        {
         "IMS": "rdcrimetype",
         "HOF": "crime-type"
         },
@@ -247,6 +251,10 @@
         {
         "IMS": "lswherecountry",
         "HOF": "crime-location-country"
+        },
+        {
+         "IMS": "txwhereaddress",
+         "HOF": "crime-location-address"
         },
         {
         "IMS": "txwherepostcode",

--- a/lib/ims-hof-values-map.json
+++ b/lib/ims-hof-values-map.json
@@ -202,6 +202,14 @@
              "IMS": "BoatType.Bulk_Carrier"
             },
             {
+             "HOF": "vehicle-carrier",
+             "IMS": "BoatType.VehicleCarrier"
+            },
+            {
+             "HOF": "vessel-carrier",
+             "IMS": "BoatType.VesselCarrier"
+            },
+            {
              "HOF": "cabin-cruiser",
              "IMS": "BoatType.Cabin_Cruiser"
             },

--- a/test/_unit/behaviours/vehicle-toggle-formatter.spec.js
+++ b/test/_unit/behaviours/vehicle-toggle-formatter.spec.js
@@ -1,0 +1,260 @@
+'use strict';
+
+const Controller = require('hof').controller;
+const Behaviour = require('../../../apps/paf/behaviours/vehicle-toggle-formatter');
+
+describe('apps/paf/behaviours/vehicle-toggle-formatter', () => {
+  describe('process', () => {
+    let controller;
+    let req;
+    let res;
+    let sandbox;
+
+    beforeEach(done => {
+
+      req = reqres.req();
+      res = reqres.res();
+      req.sessionModel.attributes.steps = [];
+
+      const VehicleToggleFormatterController = Behaviour(Controller);
+      controller = new VehicleToggleFormatterController({ template: 'index', route: '/index' });
+      controller._configure(req, res, done);
+    });
+
+    describe('formats vehicle-type, boat-type and report-person-transport-type that come from radio toggle', () => {
+      beforeEach(() => {
+        sandbox = sinon.createSandbox();
+
+        sandbox.stub(Controller.prototype, 'process').yieldsAsync();
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it(`sets 'car' as vehicle-type`, () => {
+        req.sessionModel.set('crime-car-group',  'car' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('vehicle-type').should.deep.equal('car');
+        })
+      });
+      
+      it(`sets 'car-transporter' as vehicle-type`, () => {
+        req.sessionModel.set('crime-car-group',  'car-transporter' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('vehicle-type').should.deep.equal('car-transporter');
+        })
+      });
+
+      it(`sets 'hgv-canvas-sided' as vehicle-type`, () => {
+        req.sessionModel.set('crime-hgv-group',  'hgv-canvas-sided' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('vehicle-type').should.deep.equal('hgv-canvas-sided');
+        })
+      });
+
+      it(`sets 'hgv-flatbed' as vehicle-type`, () => {
+        req.sessionModel.set('crime-hgv-group',  'hgv-flatbed' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('vehicle-type').should.deep.equal('hgv-flatbed');
+        })
+      });
+
+      it(`sets 'hgv-hard-sided' as vehicle-type`, () => {
+        req.sessionModel.set('crime-hgv-group',  'hgv-hard-sided' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('vehicle-type').should.deep.equal('hgv-hard-sided');
+        })
+      });
+
+      it(`sets 'hgv-fridgerated' as vehicle-type`, () => {
+        req.sessionModel.set('crime-hgv-group',  'hgv-fridgerated' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('vehicle-type').should.deep.equal('hgv-fridgerated');
+        })
+      });
+
+      it(`sets 'lorry' as vehicle-type`, () => {
+        req.sessionModel.set('crime-lorry-group',  'lorry' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('vehicle-type').should.deep.equal('lorry');
+        })
+      });
+
+      it(`sets 'lorry-drag' as vehicle-type`, () => {
+        req.sessionModel.set('crime-lorry-group',  'lorry-and-drag' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('vehicle-type').should.deep.equal('lorry-and-drag');
+        })
+      });
+
+      it(`sets 'van' as vehicle-type`, () => {
+        req.sessionModel.set('crime-van-group',  'van' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('vehicle-type').should.deep.equal('van');
+        })
+      });
+
+      it(`sets 'van-and-trailer' as vehicle-type`, () => {
+        req.sessionModel.set('crime-van-group',  'van-and-trailer' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('vehicle-type').should.deep.equal('van-and-trailer');
+        })
+      });
+
+      it(`sets 'van-other' as vehicle-type`, () => {
+        req.sessionModel.set('crime-van-group',  'van-other' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('vehicle-type').should.deep.equal('van-other');
+        })
+      });
+
+      it(`sets 'seven-point-five-tonne-van' as vehicle-type`, () => {
+        req.sessionModel.set('crime-van-group',  'seven-point-five-tonne-van' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('vehicle-type').should.deep.equal('seven-point-five-tonne-van');
+        })
+      });
+
+      it(`sets 'bulk-carrier' as vehicle-type`, () => {
+        req.sessionModel.set('crime-carrier-group', 'bulk-carrier' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('boat-type').should.deep.equal('bulk-carrier');
+        })
+      });
+
+      it(`sets 'vehicle carrier' as vehicle-type`, () => {
+        req.sessionModel.set('crime-carrier-group', 'vehicle-carrier' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('boat-type').should.deep.equal('vehicle-carrier');
+        })
+      });
+
+      it(`sets 'vessel carrier' as boat-type`, () => {
+        req.sessionModel.set('crime-carrier-group', 'vessel-carrier' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('boat-type').should.deep.equal('vessel-carrier');
+        })
+      });
+
+      it(`sets 'general-cargo' as boat-type`, () => {
+        req.sessionModel.set('crime-general-cargo-group', 'general-cargo' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('boat-type').should.deep.equal('general-cargo');
+        })
+      });
+
+      it(`sets 'general-cargo-with-container-capacity' as boat-type`, () => {
+        req.sessionModel.set('crime-general-cargo-group', 'general-cargo-with-container-capacity' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('boat-type').should.deep.equal('general-cargo-with-container-capacity');
+        })
+      });
+
+      it(`sets 'research-vessel' as boat-type`, () => {
+        req.sessionModel.set('crime-vessel-group',  'research-vessel' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('boat-type').should.deep.equal('research-vessel');
+        })
+      });
+
+      it(`sets 'supply-vessel' as boat-type`, () => {
+        req.sessionModel.set('crime-vessel-group', 'supply-vessel' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('boat-type').should.deep.equal('supply-vessel');
+        })
+      });
+
+      it(`sets 'support-vessel' as boat-type`, () => {
+        req.sessionModel.set('crime-vessel-group', 'support-vessel' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('boat-type').should.deep.equal('support-vessel');
+        })
+      });
+
+      it(`sets 'car' as report-person-transport-type`, () => {
+        req.sessionModel.set('report-person-transport-car-group',  'car' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('report-person-transport-type').should.deep.equal('car');
+        })
+      });
+
+      it(`sets 'car-transporter' as report-person-transport-type`, () => {
+        req.sessionModel.set('report-person-transport-car-group',  'car-transporter' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('report-person-transport-type').should.deep.equal('car-transporter');
+        })
+      });
+      
+      it(`sets 'hgv-canvas-sided' as report-person-transport-type`, () => {
+        req.sessionModel.set('report-person-transport-hgv-group', 'hgv-canvas-sided' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('report-person-transport-type').should.deep.equal('hgv-canvas-sided');
+        })
+      });
+
+      it(`sets 'hgv-flatbed' as report-person-transport-type`, () => {
+        req.sessionModel.set('report-person-transport-hgv-group', 'hgv-flatbed' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('report-person-transport-type').should.deep.equal('hgv-flatbed');
+        })
+      });
+
+      it(`sets 'hgv-hard-sided' as report-person-transport-type`, () => {
+        req.sessionModel.set('report-person-transport-hgv-group', 'hgv-hard-sided' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('report-person-transport-type').should.deep.equal('hgv-hard-sided');
+        })
+      });
+
+      it(`sets 'hgv-fridgerated' as report-person-transport-type`, () => {
+        req.sessionModel.set('report-person-transport-hgv-group', 'hgv-fridgerated' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('report-person-transport-type').should.deep.equal('hgv-fridgerated');
+        })
+      });
+
+      it(`sets 'lorry' as report-person-transport-type`, () => {
+        req.sessionModel.set('report-person-transport-lorry-group', 'lorry' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('report-person-transport-type').should.deep.equal('lorry');
+        })
+      });
+
+      it(`sets 'lorry-drag' as report-person-transport-type`, () => {
+        req.sessionModel.set('report-person-transport-lorry-group', 'lorry-and-drag' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('report-person-transport-type').should.deep.equal('lorry-and-drag');
+        })
+      });
+
+      it(`sets 'van' as report-person-transport-type`, () => {
+        req.sessionModel.set('report-person-transport-van-group', 'van' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('report-person-transport-type').should.deep.equal('van');
+        })
+      });
+
+      it(`sets 'van-and-trailer' as report-person-transport-type`, () => {
+        req.sessionModel.set('report-person-transport-van-group', 'van-and-trailer' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('report-person-transport-type').should.deep.equal('van-and-trailer');
+        })
+      });
+
+      it(`sets 'van-other' as report-person-transport-type`, () => {
+        req.sessionModel.set('report-person-transport-van-group', 'van-other' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('report-person-transport-type').should.deep.equal('van-other');
+        })
+      });
+
+      it(`sets 'seven-point-five-tonne-van' as report-person-transport-type`, () => {
+        req.sessionModel.set('report-person-transport-van-group', 'seven-point-five-tonne-van' );
+        controller.process(req, res, () => {
+          req.sessionModel.get('report-person-transport-type').should.deep.equal('seven-point-five-tonne-van');
+        })
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What?
- Format radio toggles for vehicle-type, boat-type, and report transport-type so they are mapped to IMS values
- Applied the formatting behaviours to the declaration page, to avoid conflicts with other behaviours
- Add missing values and field objects for mapping
## Why?
- The radio toggle values had a different field name and so were not being mapped 
## How?
- Created a behaviour to set toggled field values to the relevant vehicle-type, boat-type or report-person-transport-type so they are mapped to IMS correctly
## Testing?
Tests passing
## Screenshots (optional)
## Anything Else? (optional)
