### PR TITLE
remove url validate from person and company manager fields

### DIFF
--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -900,7 +900,7 @@ module.exports = {
   },
   'report-person-study-manager': {
     mixin: 'input-text',
-    validate: ['url', { type: 'maxlength', arguments: 100 }]
+    validate: [{ type: 'maxlength', arguments: 100 }]
   },
   'report-person-study-manager-know': {
     mixin: 'radio-group',
@@ -1166,7 +1166,7 @@ module.exports = {
   },
   'company-owner': {
     mixin: 'input-text',
-    validate: ['url', { type: 'maxlength', arguments: 100 }]
+    validate: [{ type: 'maxlength', arguments: 100 }]
   },
   'owner-know-about-the-crime': {
     mixin: 'radio-group',


### PR DESCRIPTION
## What?
- remove url validate copied into person and company manager fields
## Why?
- was causing validation error to flag when url validation was not required
## How?
- removed url validate from person and company manager fields
## Testing?
tests passing locally
## Screenshots (optional)
## Anything Else? (optional)
