### PR TITLE
Paf 66 radio toggle bug fix

### DIFF
--- a/apps/paf/behaviours/set-transport-toggle.js
+++ b/apps/paf/behaviours/set-transport-toggle.js
@@ -1,0 +1,84 @@
+module.exports = superclass => class extends superclass {
+  locals(req, res) {
+    const locals = super.locals(req, res);
+
+    // set crime-transport-vehicle toggles
+    if (req.form.values['crime-car-group'] === 'car') {
+      locals.carChecked = true;
+    } else if (req.form.values['crime-car-group'] === 'car-transporter') {
+      locals.carTransporterChecked = true;
+    } else if (req.form.values['crime-hgv-group'] === 'hgv-canvas-sided') {
+      locals.hgvCSChecked = true;
+    } else if (req.form.values['crime-hgv-group'] === 'hgv-flatbed') {
+      locals.hgvFChecked = true;
+    } else if (req.form.values['crime-hgv-group'] === 'hgv-hard-sided') {
+      locals.hgvHSChecked = true;
+    } else if (req.form.values['crime-hgv-group'] === 'hgv-refridgerated') {
+      locals.hgvRChecked = true;
+    } else if (req.form.values['crime-hgv-group'] === 'hgv-tanker') {
+      locals.hgvTChecked = true;
+    } else if (req.form.values['crime-lorry-group'] === 'lorry') {
+      locals.lorryChecked = true;
+    } else if (req.form.values['crime-lorry-group'] === 'lorry-and-drag') {
+      locals.lorryDragChecked = true;
+    } else if (req.form.values['crime-van-group'] === 'van') {
+      locals.vanChecked = true;
+    } else if (req.form.values['crime-van-group'] === 'van-and-trailer') {
+      locals.vanTrailerChecked = true;
+    } else if (req.form.values['crime-van-group'] === 'van-other') {
+      locals.vanOtherChecked = true;
+    } else if (req.form.values['crime-van-group'] === 'seven-point-five-tonne-van') {
+      locals.sevenVanChecked = true;
+    }
+
+    // set crime-transport-boat toggles
+    if (req.form.values['crime-carrier-group'] === 'bulk-carrier') {
+      locals.bulkChecked = true;
+    } else if (req.form.values['crime-carrier-group'] === 'vehicle-carrier') {
+      locals.vehicleChecked = true;
+    } else if (req.form.values['crime-carrier-group'] === 'vessel-carrier') {
+      locals.vesselChecked = true;
+    } else if (req.form.values['crime-general-cargo-group'] === 'general-cargo') {
+      locals.generalChecked = true;
+    } else if (req.form.values['crime-general-cargo-group'] === 'general-cargo-with-container-capacity') {
+      locals.generalContainerChecked = true;
+    } else if (req.form.values['crime-vessel-group'] === 'research-vessel') {
+      locals.researchChecked = true;
+    } else if (req.form.values['crime-vessel-group'] === 'supply-vessel') {
+      locals.supplyChecked = true;
+    } else if (req.form.values['crime-vessel-group'] === 'support-vessel') {
+      locals.supportChecked = true;
+    }
+
+    // set report-person-transport toggles
+    if (req.form.values['report-person-transport-car-group'] === 'car') {
+      locals.personCarChecked = true;
+    } else if (req.form.values['report-person-transport-car-group'] === 'car-transporter') {
+      locals.personCarTransporterChecked = true;
+    } else if (req.form.values['report-person-transport-hgv-group'] === 'hgv-canvas-sided') {
+      locals.personHgvCSChecked = true;
+    } else if (req.form.values['report-person-transport-hgv-group'] === 'hgv-flatbed') {
+      locals.personHgvFChecked = true;
+    } else if (req.form.values['report-person-transport-hgv-group'] === 'hgv-hard-sided') {
+      locals.personHgvHSChecked = true;
+    } else if (req.form.values['report-person-transport-hgv-group'] === 'hgv-refridgerated') {
+      locals.personHgvRChecked = true;
+    } else if (req.form.values['report-person-transport-hgv-group'] === 'hgv-tanker') {
+      locals.personHgvTChecked = true;
+    } else if (req.form.values['report-person-transport-lorry-group'] === 'lorry') {
+      locals.personLorryChecked = true;
+    } else if (req.form.values['report-person-transport-lorry-group'] === 'lorry-and-drag') {
+      locals.personLorryDragChecked = true;
+    } else if (req.form.values['report-person-transport-van-group'] === 'van') {
+      locals.personVanChecked = true;
+    } else if (req.form.values['report-person-transport-van-group'] === 'van-and-trailer') {
+      locals.personVanTrailerChecked = true;
+    } else if (req.form.values['report-person-transport-van-group'] === 'van-other') {
+      locals.personVanOtherChecked = true;
+    } else if (req.form.values['report-person-transport-van-group'] === 'seven-point-five-tonne-van') {
+      locals.personSevenVanChecked = true;
+    }
+
+    return locals;
+  }
+};

--- a/apps/paf/index.js
+++ b/apps/paf/index.js
@@ -6,6 +6,7 @@ const limitDocs = require('./behaviours/limit-documents');
 const disableUpload = require('./behaviours/disable-file-upload');
 const SummaryPageBehaviour = require('hof').components.summary;
 const transportBehaviour = require('./behaviours/transport-behaviour');
+const transportToggle = require('./behaviours/set-transport-toggle');
 const Aggregate = require('./behaviours/aggregator');
 const limitPerson = require('./behaviours/limit-person');
 const personNumber = require('./behaviours/person-number');
@@ -114,6 +115,7 @@ module.exports = {
       continueOnEdit: true
     },
     '/crime-transport-vehicle-type': {
+      behaviours: [transportToggle],
       fields: ['vehicle-type',
         'crime-car-group',
         'crime-hgv-group',
@@ -163,6 +165,7 @@ module.exports = {
       continueOnEdit: true
     },
     '/crime-transport-boat-type': {
+      behaviours: [transportToggle],
       fields: ['boat-type',
         'crime-carrier-group',
         'crime-general-cargo-group',
@@ -544,6 +547,7 @@ module.exports = {
       ]
     },
     '/report-person-transport-type': {
+      behaviours: [transportToggle],
       fields: ['report-person-transport-type',
         'report-person-transport-car-group',
         'report-person-transport-hgv-group',

--- a/apps/paf/views/partials/crime-car-group.html
+++ b/apps/paf/views/partials/crime-car-group.html
@@ -2,17 +2,17 @@
   <fieldset class="govuk-fieldset">
     <div class="govuk-radios" data-module="govuk-radios">
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input" type="radio" name="crime-car-group" id="crime-car-group-car" value="car">
+        <input class="govuk-radios__input" type="radio" name="crime-car-group" id="crime-car-group-car" value="car" {{#carChecked}} checked="checked"{{/carChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-car-group-car">
           {{#t}}fields.crime-car-group.options.car{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="crime-car-group" id="crime-car-group-car-transporter"  value="car-transporter">
+        <input class="govuk-radios__input"  type="radio" name="crime-car-group" id="crime-car-group-car-transporter"  value="car-transporter" {{#carTransporterChecked}} checked="checked"{{/carTransporterChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-car-group-car-transporter">
           {{#t}}fields.crime-car-group.options.car-transporter{{/t}}
         </label>
       </div>
     </div>
   </fieldset>
-</div>
+</div>   

--- a/apps/paf/views/partials/crime-carrier-group.html
+++ b/apps/paf/views/partials/crime-carrier-group.html
@@ -2,19 +2,19 @@
   <fieldset class="govuk-fieldset">
     <div class="govuk-radios" data-module="govuk-radios">
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input" type="radio" name="crime-carrier-group" id="crime-carrier-group-bulk-carrier" value="bulk-carrier">
+        <input class="govuk-radios__input" type="radio" name="crime-carrier-group" id="crime-carrier-group-bulk-carrier" value="bulk-carrier" {{#bulkChecked}}checked="checked"{{/bulkChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-carrier-group-bulk-carrier">
           {{#t}}fields.crime-carrier-group.options.bulk-carrier{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="crime-carrier-group" id="crime-carrier-group-vehicle-carrier"  value="vehicle-carrier">
+        <input class="govuk-radios__input"  type="radio" name="crime-carrier-group" id="crime-carrier-group-vehicle-carrier"  value="vehicle-carrier" {{#vehicleChecked}}checked="checked"{{/vehicleChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-carrier-group-vehicle-carrier">
           {{#t}}fields.crime-carrier-group.options.vehicle-carrier{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="crime-carrier-group" id="crime-carrier-group-vessel-carrier"  value="vessel-carrier">
+        <input class="govuk-radios__input"  type="radio" name="crime-carrier-group" id="crime-carrier-group-vessel-carrier"  value="vessel-carrier" {{#vesselChecked}}checked="checked"{{/vesselChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-carrier-group-vessel-carrier">
           {{#t}}fields.crime-carrier-group.options.vessel-carrier{{/t}}
         </label>

--- a/apps/paf/views/partials/crime-general-cargo-group.html
+++ b/apps/paf/views/partials/crime-general-cargo-group.html
@@ -2,13 +2,13 @@
   <fieldset class="govuk-fieldset">
     <div class="govuk-radios" data-module="govuk-radios">
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="crime-general-cargo-group" id="crime-general-cargo-group-general-cargo"  value="general-cargo">
+        <input class="govuk-radios__input"  type="radio" name="crime-general-cargo-group" id="crime-general-cargo-group-general-cargo"  value="general-cargo" {{#generalChecked}}checked="checked"{{/generalChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-general-cargo-group-general-cargo">
           {{#t}}fields.crime-general-cargo-group.options.general-cargo{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="crime-general-cargo-group" id="crime-general-cargo-group-general-cargo-with-container-capacity"  value="general-cargo-with-container-capacity">
+        <input class="govuk-radios__input"  type="radio" name="crime-general-cargo-group" id="crime-general-cargo-group-general-cargo-with-container-capacity"  value="general-cargo-with-container-capacity" {{#generalContainerChecked}}checked="checked"{{/generalContainerChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-general-cargo-group-general-cargo-with-container-capacity">
           {{#t}}fields.crime-general-cargo-group.options.general-cargo-with-container-capacity{{/t}}
         </label>

--- a/apps/paf/views/partials/crime-hgv-group.html
+++ b/apps/paf/views/partials/crime-hgv-group.html
@@ -2,31 +2,31 @@
   <fieldset class="govuk-fieldset">
     <div class="govuk-radios" data-module="govuk-radios">
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input" type="radio" name="crime-hgv-group" id="crime-hgv-group-hgv-canvas-sided" value="hgv-canvas-sided">
+        <input class="govuk-radios__input" type="radio" name="crime-hgv-group" id="crime-hgv-group-hgv-canvas-sided" value="hgv-canvas-sided" {{#hgvCSChecked}}checked="checked"{{/hgvCSChecked}} >
         <label class="govuk-label govuk-radios__label" for="crime-hgv-group-hgv-canvas-sided">
           {{#t}}fields.crime-hgv-group.options.hgv-canvas-sided{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="crime-hgv-group" id="crime-hgv-group-hgv-flatbed"  value="hgv-flatbed">
+        <input class="govuk-radios__input"  type="radio" name="crime-hgv-group" id="crime-hgv-group-hgv-flatbed"  value="hgv-flatbed" {{#hgvFChecked}}checked="checked"{{/hgvFChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-hgv-group-hgv-flatbed">
           {{#t}}fields.crime-hgv-group.options.hgv-flatbed{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="crime-hgv-group" id="crime-hgv-group-hgv-hard-sided"  value="hgv-hard-sided">
+        <input class="govuk-radios__input"  type="radio" name="crime-hgv-group" id="crime-hgv-group-hgv-hard-sided"  value="hgv-hard-sided" {{#hgvHSChecked}}checked="checked"{{/hgvHSChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-hgv-group-hgv-hard-sided">
           {{#t}}fields.crime-hgv-group.options.hgv-hard-sided{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="crime-hgv-group" id="crime-hgv-group-hgv-refridgerated"  value="hgv-refridgerated">
+        <input class="govuk-radios__input"  type="radio" name="crime-hgv-group" id="crime-hgv-group-hgv-refridgerated"  value="hgv-refridgerated" {{#hgvRChecked}}checked="checked"{{/hgvRChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-hgv-group-hgv-refridgerated">
           {{#t}}fields.crime-hgv-group.options.hgv-refridgerated{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="crime-hgv-group" id="crime-hgv-group-hgv-tanker"  value="hgv-tanker">
+        <input class="govuk-radios__input"  type="radio" name="crime-hgv-group" id="crime-hgv-group-hgv-tanker"  value="hgv-tanker" {{#hgvTChecked}}checked="checked"{{/hgvTChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-hgv-group-hgv-tanker">
           {{#t}}fields.crime-hgv-group.options.hgv-tanker{{/t}}
         </label>

--- a/apps/paf/views/partials/crime-lorry-group.html
+++ b/apps/paf/views/partials/crime-lorry-group.html
@@ -2,13 +2,13 @@
   <fieldset class="govuk-fieldset">
     <div class="govuk-radios" data-module="govuk-radios">
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input" type="radio" name="crime-lorry-group" id="crime-lorry-group-lorry" value="lorry">
+        <input class="govuk-radios__input" type="radio" name="crime-lorry-group" id="crime-lorry-group-lorry" value="lorry" {{#lorryChecked}} checked="checked"{{/lorryChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-lorry-group-lorry">
           {{#t}}fields.crime-lorry-group.options.lorry{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="crime-lorry-group" id="crime-lorry-group-lorry-and-drag"  value="lorry-and-drag">
+        <input class="govuk-radios__input"  type="radio" name="crime-lorry-group" id="crime-lorry-group-lorry-and-drag"  value="lorry-and-drag" {{#lorryDragChecked}} checked="checked"{{/lorryDragChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-lorry-group-lorry-and-drag">
           {{#t}}fields.crime-lorry-group.options.lorry-and-drag{{/t}}
         </label>

--- a/apps/paf/views/partials/crime-van-group.html
+++ b/apps/paf/views/partials/crime-van-group.html
@@ -2,25 +2,25 @@
   <fieldset class="govuk-fieldset">
     <div class="govuk-radios" data-module="govuk-radios">
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input" type="radio" name="crime-van-group" id="crime-van-group-van" value="van">
+        <input class="govuk-radios__input" type="radio" name="crime-van-group" id="crime-van-group-van" value="van" {{#vanChecked}}checked="checked"{{/vanChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-van-group-van">
           {{#t}}fields.crime-van-group.options.van{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="crime-van-group" id="crime-van-group-van-and-trailer"  value="van-and-trailer">
+        <input class="govuk-radios__input"  type="radio" name="crime-van-group" id="crime-van-group-van-and-trailer"  value="van-and-trailer" {{#vanTrailerChecked}}checked="checked"{{/vanTrailerChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-van-group-van-and-trailer">
           {{#t}}fields.crime-van-group.options.van-and-trailer{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="crime-van-group" id="crime-van-group-van-other"  value="van-other">
+        <input class="govuk-radios__input"  type="radio" name="crime-van-group" id="crime-van-group-van-other"  value="van-other" {{#vanOtherChecked}}checked="checked"{{/vanOtherChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-van-group-van-other">
           {{#t}}fields.crime-van-group.options.van-other{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="crime-van-group" id="crime-van-group-seven-point-five-tonne-van"  value="seven-point-five-tonne-van">
+        <input class="govuk-radios__input"  type="radio" name="crime-van-group" id="crime-van-group-seven-point-five-tonne-van"  value="seven-point-five-tonne-van" {{#sevenVanChecked}}checked="checked"{{/sevenVanChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-van-group-seven-point-five-tonne-van">
           {{#t}}fields.crime-van-group.options.seven-point-five-tonne-van{{/t}}
         </label>

--- a/apps/paf/views/partials/crime-vessel-group.html
+++ b/apps/paf/views/partials/crime-vessel-group.html
@@ -2,19 +2,19 @@
   <fieldset class="govuk-fieldset">
     <div class="govuk-radios" data-module="govuk-radios">
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input" type="radio" name="crime-vessel-group" id="crime-vessel-group-research-vessel" value="research-vessel">
+        <input class="govuk-radios__input" type="radio" name="crime-vessel-group" id="crime-vessel-group-research-vessel" value="research-vessel" {{#researchChecked}}checked="checked"{{/researchChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-vessel-group-research-vessel">
           {{#t}}fields.crime-vessel-group.options.research-vessel{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="crime-vessel-group" id="crime-vessel-group-supply-vessel"  value="supply-vessel">
+        <input class="govuk-radios__input"  type="radio" name="crime-vessel-group" id="crime-vessel-group-supply-vessel"  value="supply-vessel" {{#supplyChecked}}checked="checked"{{/supplyChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-vessel-group-supply-vessel">
           {{#t}}fields.crime-vessel-group.options.supply-vessel{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="crime-vessel-group" id="crime-vessel-group-support-vessel"  value="support-vessel">
+        <input class="govuk-radios__input"  type="radio" name="crime-vessel-group" id="crime-vessel-group-support-vessel"  value="support-vessel" {{#supportChecked}}checked="checked"{{/supportChecked}}>
         <label class="govuk-label govuk-radios__label" for="crime-vessel-group-support-vessel">
           {{#t}}fields.crime-vessel-group.options.support-vessel{{/t}}
         </label>

--- a/apps/paf/views/partials/report-person-transport-car-group.html
+++ b/apps/paf/views/partials/report-person-transport-car-group.html
@@ -2,13 +2,13 @@
   <fieldset class="govuk-fieldset">
     <div class="govuk-radios" data-module="govuk-radios">
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input" type="radio" name="report-person-transport-car-group" id="report-person-transport-car-group-car" value="car">
+        <input class="govuk-radios__input" type="radio" name="report-person-transport-car-group" id="report-person-transport-car-group-car" value="car" {{#personCarChecked}}checked="checked"{{/personCarChecked}}>
         <label class="govuk-label govuk-radios__label" for="report-person-transport-car-group-car">
           {{#t}}fields.report-person-transport-car-group.options.car{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="report-person-transport-car-group" id="report-person-transport-car-group-car-transporter"  value="car-transporter">
+        <input class="govuk-radios__input"  type="radio" name="report-person-transport-car-group" id="report-person-transport-car-group-car-transporter"  value="car-transporter" {{#personCarTransporterChecked}}checked="checked"{{/personCarTransporterChecked}}>
         <label class="govuk-label govuk-radios__label" for="report-person-transport-car-group-car-transporter">
           {{#t}}fields.report-person-transport-car-group.options.car-transporter{{/t}}
         </label>

--- a/apps/paf/views/partials/report-person-transport-hgv-group.html
+++ b/apps/paf/views/partials/report-person-transport-hgv-group.html
@@ -2,31 +2,31 @@
   <fieldset class="govuk-fieldset">
     <div class="govuk-radios" data-module="govuk-radios">
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input" type="radio" name="report-person-transport-hgv-group" id="report-person-transport-hgv-group-hgv-canvas-sided" value="hgv-canvas-sided">
+        <input class="govuk-radios__input" type="radio" name="report-person-transport-hgv-group" id="report-person-transport-hgv-group-hgv-canvas-sided" value="hgv-canvas-sided" {{#personHgvCSChecked}}checked="checked"{{/personHgvCSChecked}}>
         <label class="govuk-label govuk-radios__label" for="report-person-transport-hgv-group-hgv-canvas-sided">
           {{#t}}fields.report-person-transport-hgv-group.options.hgv-canvas-sided{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="report-person-transport-hgv-group" id="report-person-transport-hgv-group-hgv-flatbed"  value="hgv-flatbed">
+        <input class="govuk-radios__input"  type="radio" name="report-person-transport-hgv-group" id="report-person-transport-hgv-group-hgv-flatbed"  value="hgv-flatbed" {{#personHgvFChecked}}checked="checked"{{/personHgvFChecked}}>
         <label class="govuk-label govuk-radios__label" for="report-person-transport-hgv-group-hgv-flatbed">
           {{#t}}fields.report-person-transport-hgv-group.options.hgv-flatbed{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="report-person-transport-hgv-group" id="report-person-transport-hgv-group-hgv-hard-sided"  value="hgv-hard-sided">
+        <input class="govuk-radios__input"  type="radio" name="report-person-transport-hgv-group" id="report-person-transport-hgv-group-hgv-hard-sided"  value="hgv-hard-sided" {{#personHgvHSChecked}}checked="checked"{{/personHgvHSChecked}}>
         <label class="govuk-label govuk-radios__label" for="report-person-transport-hgv-group-hgv-hard-sided">
           {{#t}}fields.report-person-transport-hgv-group.options.hgv-hard-sided{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="report-person-transport-hgv-group" id="report-person-transport-hgv-group-hgv-refridgerated"  value="hgv-refridgerated">
+        <input class="govuk-radios__input"  type="radio" name="report-person-transport-hgv-group" id="report-person-transport-hgv-group-hgv-refridgerated"  value="hgv-refridgerated" {{#personHgvRChecked}}checked="checked"{{/personHgvRChecked}}>
         <label class="govuk-label govuk-radios__label" for="report-person-transport-hgv-group-hgv-refridgerated">
           {{#t}}fields.report-person-transport-hgv-group.options.hgv-refridgerated{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="report-person-transport-hgv-group" id="report-person-transport-hgv-group-hgv-tanker"  value="hgv-tanker">
+        <input class="govuk-radios__input"  type="radio" name="report-person-transport-hgv-group" id="report-person-transport-hgv-group-hgv-tanker"  value="hgv-tanker"  {{#personHgvTChecked}}checked="checked"{{/personHgvTChecked}}>
         <label class="govuk-label govuk-radios__label" for="report-person-transport-hgv-group-hgv-tanker">
           {{#t}}fields.report-person-transport-hgv-group.options.hgv-tanker{{/t}}
         </label>

--- a/apps/paf/views/partials/report-person-transport-lorry-group.html
+++ b/apps/paf/views/partials/report-person-transport-lorry-group.html
@@ -2,13 +2,13 @@
   <fieldset class="govuk-fieldset">
     <div class="govuk-radios" data-module="govuk-radios">
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input" type="radio" name="lreport-person-transport-orry-group" id="report-person-transport-lorry-group-lorry" value="lorry">
+        <input class="govuk-radios__input" type="radio" name="report-person-transport-lorry-group" id="report-person-transport-lorry-group-lorry" value="lorry" {{#personLorryChecked}}checked="checked"{{/personLorryChecked}}>
         <label class="govuk-label govuk-radios__label" for="report-person-transport-lorry-group-lorry">
           {{#t}}fields.report-person-transport-lorry-group.options.lorry{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="report-person-transport-lorry-group" id="report-person-transport-lorry-group-lorry-and-drag"  value="lorry-and-drag">
+        <input class="govuk-radios__input"  type="radio" name="report-person-transport-lorry-group" id="report-person-transport-lorry-group-lorry-and-drag"  value="lorry-and-drag" {{#personLorryDragChecked}}checked="checked"{{/personLorryDragChecked}}>
         <label class="govuk-label govuk-radios__label" for="report-person-transport-lorry-group-lorry-and-drag">
           {{#t}}fields.report-person-transport-lorry-group.options.lorry-and-drag{{/t}}
         </label>

--- a/apps/paf/views/partials/report-person-transport-van-group.html
+++ b/apps/paf/views/partials/report-person-transport-van-group.html
@@ -2,25 +2,25 @@
   <fieldset class="govuk-fieldset">
     <div class="govuk-radios" data-module="govuk-radios">
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input" type="radio" name="report-person-transport-van-group" id="report-person-transport-van-group-van" value="van">
+        <input class="govuk-radios__input" type="radio" name="report-person-transport-van-group" id="report-person-transport-van-group-van" value="van" {{#personVanChecked}}checked="checked"{{/personVanChecked}}>
         <label class="govuk-label govuk-radios__label" for="report-person-transport-van-group-van">
           {{#t}}fields.report-person-transport-van-group.options.van{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="report-person-transport-van-group" id="report-person-transport-van-group-van-and-trailer"  value="van-and-trailer">
+        <input class="govuk-radios__input"  type="radio" name="report-person-transport-van-group" id="report-person-transport-van-group-van-and-trailer"  value="van-and-trailer" {{#personVanTrailerChecked}}checked="checked"{{/personVanTrailerChecked}}>
         <label class="govuk-label govuk-radios__label" for="report-person-transport-van-group-van-and-trailer">
           {{#t}}fields.report-person-transport-van-group.options.van-and-trailer{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="report-person-transport-van-group" id="report-person-transport-van-group-van-other"  value="van-other">
+        <input class="govuk-radios__input"  type="radio" name="report-person-transport-van-group" id="report-person-transport-van-group-van-other"  value="van-other" {{#personvanOtherChecked}}checked="checked"{{/personvanOtherChecked}}>
         <label class="govuk-label govuk-radios__label" for="report-person-transport-van-group-van-other">
           {{#t}}fields.report-person-transport-van-group.options.van-other{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="report-person-transport-van-group" id="report-person-transport-van-group-seven-point-five-tonne-van"  value="seven-point-five-tonne-van">
+        <input class="govuk-radios__input"  type="radio" name="report-person-transport-van-group" id="report-person-transport-van-group-seven-point-five-tonne-van"  value="seven-point-five-tonne-van" {{#personsevenVanChecked}}checked="checked"{{/personsevenVanChecked}}>
         <label class="govuk-label govuk-radios__label" for="report-person-transport-van-group-seven-point-five-tonne-van">
           {{#t}}fields.report-person-transport-van-group.options.seven-point-five-tonne-van{{/t}}
         </label>

--- a/test/_unit/behaviours/set-transport-toggle.spec.js
+++ b/test/_unit/behaviours/set-transport-toggle.spec.js
@@ -1,0 +1,163 @@
+/* eslint-disable max-len */
+'use strict';
+
+const Controller = require('hof').controller;
+const Behaviour = require('../../../apps/paf/behaviours/set-transport-toggle');
+
+describe('apps/paf/behaviours/set-transport-toggle', () => {
+  describe('locals', () => {
+    let controller;
+    let req;
+    let res;
+
+    beforeEach(done => {
+      req = reqres.req();
+      res = reqres.res();
+      const TransportToggleController = Behaviour(Controller);
+      controller = new TransportToggleController({ template: 'index', route: '/index' });
+      controller._configure(req, res, done);
+    });
+
+    describe('crime transport group toggled options should be checked if selected', () => {
+      it('locals should have carChecked property as true if car has been selected', () => {
+        req.form.values['crime-car-group'] = 'car';
+        controller.locals(req, res).should.have.property('carChecked').and.deep.equal(true);
+      });
+      it('locals should have carTransporterChecked property as true if car transporter has been selected', () => {
+        req.form.values['crime-car-group'] = 'car-transporter';
+        controller.locals(req, res).should.have.property('carTransporterChecked').and.deep.equal(true);
+      });
+      it('locals should have hgvCSChecked property as true if hgv canvas sided has been selected', () => {
+        req.form.values['crime-hgv-group'] = 'hgv-canvas-sided';
+        controller.locals(req, res).should.have.property('hgvCSChecked').and.deep.equal(true);
+      });
+      it('locals should have hgvFChecked property as true if hgv flatbed has been selected', () => {
+        req.form.values['crime-hgv-group'] = 'hgv-flatbed';
+        controller.locals(req, res).should.have.property('hgvFChecked').and.deep.equal(true);
+      });
+      it('locals should have hgvHSChecked property as true if hgv hard sided has been selected', () => {
+        req.form.values['crime-hgv-group'] = 'hgv-hard-sided';
+        controller.locals(req, res).should.have.property('hgvHSChecked').and.deep.equal(true);
+      });
+      it('locals should have hgvRChecked property as true if hgv refridgerated has been selected', () => {
+        req.form.values['crime-hgv-group'] = 'hgv-refridgerated';
+        controller.locals(req, res).should.have.property('hgvRChecked').and.deep.equal(true);
+      });
+      it('locals should have hgvTCheckedproperty as true if hgv tanker has been selected', () => {
+        req.form.values['crime-hgv-group'] = 'hgv-tanker';
+        controller.locals(req, res).should.have.property('hgvTChecked').and.deep.equal(true);
+      });
+      it('locals should have lorryChecked property as true if lorry has been selected', () => {
+        req.form.values['crime-lorry-group'] = 'lorry';
+        controller.locals(req, res).should.have.property('lorryChecked').and.deep.equal(true);
+      });
+      it('locals should have lorryDragChecked property as true if lorry and drag has been selected', () => {
+        req.form.values['crime-lorry-group'] = 'lorry-and-drag';
+        controller.locals(req, res).should.have.property('lorryDragChecked').and.deep.equal(true);
+      });
+      it('locals should have vanChecked property as true if van has been selected', () => {
+        req.form.values['crime-van-group'] = 'van';
+        controller.locals(req, res).should.have.property('vanChecked').and.deep.equal(true);
+      });
+      it('locals should have vanTrailerChecked property as true if van and trailer has been selected', () => {
+        req.form.values['crime-van-group'] = 'van-and-trailer';
+        controller.locals(req, res).should.have.property('vanTrailerChecked').and.deep.equal(true);
+      });
+      it('locals should have vanOtherChecked property as true if car van - other has been selected', () => {
+        req.form.values['crime-van-group'] = 'van-other';
+        controller.locals(req, res).should.have.property('vanOtherChecked').and.deep.equal(true);
+      });
+      it('locals should have sevenVanChecked property as true if 7.5 tonne van has been selected', () => {
+        req.form.values['crime-van-group'] = 'seven-point-five-tonne-van';
+        controller.locals(req, res).should.have.property('sevenVanChecked').and.deep.equal(true);
+      });
+      it('locals should have bulkChecked property as true if bulk carrier has been selected', () => {
+        req.form.values['crime-carrier-group'] = 'bulk-carrier';
+        controller.locals(req, res).should.have.property('bulkChecked').and.deep.equal(true);
+      });
+      it('locals should have vehicleChecked property as true if vehicle carrier has been selected', () => {
+        req.form.values['crime-carrier-group'] = 'vehicle-carrier';
+        controller.locals(req, res).should.have.property('vehicleChecked').and.deep.equal(true);
+      });
+      it('locals should have vesselChecked property as true if vessel carrier has been selected', () => {
+        req.form.values['crime-carrier-group'] = 'vessel-carrier';
+        controller.locals(req, res).should.have.property('vesselChecked').and.deep.equal(true);
+      });
+      it('locals should have generalChecked property as true if general cargo has been selected', () => {
+        req.form.values['crime-general-cargo-group'] = 'general-cargo';
+        controller.locals(req, res).should.have.property('generalChecked').and.deep.equal(true);
+      });
+      it('locals should have generalContainerChecked property as true if general cargo with container capacity has been selected', () => {
+        req.form.values['crime-general-cargo-group'] = 'general-cargo-with-container-capacity';
+        controller.locals(req, res).should.have.property('generalContainerChecked').and.deep.equal(true);
+      });
+      it('locals should have researchChecked property as true if research vessel has been selected', () => {
+        req.form.values['crime-vessel-group'] = 'research-vessel';
+        controller.locals(req, res).should.have.property('researchChecked').and.deep.equal(true);
+      });
+      it('locals should have supplyChecked property as true if supply vessel has been selected', () => {
+        req.form.values['crime-vessel-group'] = 'supply-vessel';
+        controller.locals(req, res).should.have.property('supplyChecked').and.deep.equal(true);
+      });
+      it('locals should have supportChecked property as true if support vessel has been selected', () => {
+        req.form.values['crime-vessel-group'] = 'support-vessel';
+        controller.locals(req, res).should.have.property('supportChecked').and.deep.equal(true);
+      });
+    });
+
+    describe('report person transport group toggled options should be checked if selected', () => {
+      it('locals should have personCarChecked property as true if car has been selected', () => {
+        req.form.values['report-person-transport-car-group'] = 'car';
+        controller.locals(req, res).should.have.property('personCarChecked').and.deep.equal(true);
+      });
+      it('locals should have personCarTransporterChecked property as true if car transporter has been selected', () => {
+        req.form.values['report-person-transport-car-group'] = 'car-transporter';
+        controller.locals(req, res).should.have.property('personCarTransporterChecked').and.deep.equal(true);
+      });
+      it('locals should have personHgvCSChecked property as true if hgv canvas sided has been selected', () => {
+        req.form.values['report-person-transport-hgv-group'] = 'hgv-canvas-sided';
+        controller.locals(req, res).should.have.property('personHgvCSChecked').and.deep.equal(true);
+      });
+      it('locals should have personHgvFChecked property as true if hgv flatbed has been selected', () => {
+        req.form.values['report-person-transport-hgv-group'] = 'hgv-flatbed';
+        controller.locals(req, res).should.have.property('personHgvFChecked').and.deep.equal(true);
+      });
+      it('locals should have personHgvHSChecked property as true if hgv hard sided has been selected', () => {
+        req.form.values['report-person-transport-hgv-group'] = 'hgv-hard-sided';
+        controller.locals(req, res).should.have.property('personHgvHSChecked').and.deep.equal(true);
+      });
+      it('locals should have personHgvRChecked property as true if hgv refridgerated has been selected', () => {
+        req.form.values['report-person-transport-hgv-group'] = 'hgv-refridgerated';
+        controller.locals(req, res).should.have.property('personHgvRChecked').and.deep.equal(true);
+      });
+      it('locals should have personHgvTChecked property as true if hgv tanker has been selected', () => {
+        req.form.values['report-person-transport-hgv-group'] = 'hgv-tanker';
+        controller.locals(req, res).should.have.property('personHgvTChecked').and.deep.equal(true);
+      });
+      it('locals should have personLorryChecked property as true if lorry has been selected', () => {
+        req.form.values['report-person-transport-lorry-group'] = 'lorry';
+        controller.locals(req, res).should.have.property('personLorryChecked').and.deep.equal(true);
+      });
+      it('locals should have personLorryDragChecked property as true if lorry and drag has been selected', () => {
+        req.form.values['report-person-transport-lorry-group'] = 'lorry-and-drag';
+        controller.locals(req, res).should.have.property('personLorryDragChecked').and.deep.equal(true);
+      });
+      it('locals should have personVanChecked property as true if van has been selected', () => {
+        req.form.values['report-person-transport-van-group'] = 'van';
+        controller.locals(req, res).should.have.property('personVanChecked').and.deep.equal(true);
+      });
+      it('locals should have personVanTrailerChecked property as true if van and trailer has been selected', () => {
+        req.form.values['report-person-transport-van-group'] = 'van-and-trailer';
+        controller.locals(req, res).should.have.property('personVanTrailerChecked').and.deep.equal(true);
+      });
+      it('locals should have personVanOtherChecked property as true if car van-other has been selected', () => {
+        req.form.values['report-person-transport-van-group'] = 'van-other';
+        controller.locals(req, res).should.have.property('personVanOtherChecked').and.deep.equal(true);
+      });
+      it('locals should have personSevenVanChecked property as true if 7.5 tonne van has been selected', () => {
+        req.form.values['report-person-transport-van-group'] = 'seven-point-five-tonne-van';
+        controller.locals(req, res).should.have.property('personSevenVanChecked').and.deep.equal(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What?
- Radio toggle bug fix
## Why?
- To fix bug which caused vehicle and boat types selected from radio toggle to unset once the user left the page
## How?
- Added a behaviour that set the relevant radio toggle transport field as 'checked' when the user selects it.
## Testing?
- Tests passing locally
## Screenshots (optional)
## Anything Else? (optional)
