### PR TITLE
PAF-129/ PAF-128 - Fix bug to add country from list and validate country textbox.

### DIFF
--- a/apps/paf/behaviours/unset-crime-country.js
+++ b/apps/paf/behaviours/unset-crime-country.js
@@ -1,0 +1,10 @@
+'use strict';
+
+
+module.exports = superclass => class extends superclass {
+  getValues(req) {
+    req.sessionModel.unset('crime-location-country');
+    req.sessionModel.unset('crime-another-location-country');
+    return super.getValues.apply(this, arguments);
+  }
+};

--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -368,6 +368,7 @@ module.exports = {
   'boat-country-departure': {
     mixin: 'select',
     className: ['typeahead', 'js-hidden'],
+    validate: ['required', 'notUrl'],
     options:
       [{
         value: '',
@@ -402,6 +403,7 @@ module.exports = {
   'train-country-departure': {
     mixin: 'select',
     className: ['typeahead', 'js-hidden'],
+    validate: ['required', 'notUrl'],
     options:
       [{
         value: '',
@@ -439,6 +441,7 @@ module.exports = {
   'airline-country-departure': {
     mixin: 'select',
     className: ['typeahead', 'js-hidden'],
+    validate: ['required', 'notUrl'],
     options:
       [{
         value: '',
@@ -531,6 +534,7 @@ module.exports = {
   'crime-location-country': {
     mixin: 'select',
     className: ['typeahead', 'js-hidden'],
+    validate: ['required', 'notUrl'],
     options:
       [{
         value: '',
@@ -578,7 +582,11 @@ module.exports = {
   },
   'crime-location-phone': {
     className: ['govuk-input', 'govuk-input--width-20'],
-    validate: [{ type: 'maxlength', arguments: 20 }]
+    validate: ['required', { type: 'maxlength', arguments: 20 }],
+    dependent: {
+      field: 'crime-location',
+      value: 'yes'
+    }
   },
   'crime-another-location': {
     isPageHeading: true,
@@ -594,6 +602,7 @@ module.exports = {
   'crime-another-location-country': {
     mixin: 'select',
     className: ['typeahead', 'js-hidden'],
+    validate: ['required', 'notUrl'],
     options:
       [{
         value: '',
@@ -641,7 +650,11 @@ module.exports = {
   },
   'crime-another-location-phone': {
     className: ['govuk-input', 'govuk-input--width-20'],
-    validate: [{ type: 'maxlength', arguments: 20 }]
+    validate: ['required', { type: 'maxlength', arguments: 20 }],
+    dependent: {
+      field: 'crime-another-location',
+      value: 'yes'
+    }
   },
   'report-person': {
     mixin: 'radio-group',
@@ -742,6 +755,7 @@ module.exports = {
   'report-person-location-outside-uk-address-country': {
     mixin: 'select',
     className: ['typeahead', 'js-hidden'],
+    validate: ['required', 'notUrl'],
     options:
       [{
         value: '',
@@ -768,6 +782,7 @@ module.exports = {
   'report-person-location-travel-to-uk-country': {
     mixin: 'select',
     className: ['typeahead', 'js-hidden'],
+    validate: ['required', 'notUrl'],
     options:
       [{
         value: '',
@@ -789,7 +804,7 @@ module.exports = {
   },
   'report-person-location-phone': {
     className: ['govuk-input', 'govuk-input--width-20'],
-    validate: [{ type: 'maxlength', arguments: 20 }]
+    validate: ['required', { type: 'maxlength', arguments: 20 }]
   },
   'report-person-location-email': {
     validate: ['email', { type: 'maxlength', arguments: 100 }]
@@ -873,7 +888,7 @@ module.exports = {
   },
   'report-person-occupation-company-phone': {
     className: ['govuk-input', 'govuk-input--width-20'],
-    validate: [{ type: 'maxlength', arguments: 20 }]
+    validate: ['required', { type: 'maxlength', arguments: 20 }]
   },
   'report-person-occupation-company-manager': {
     mixin: 'input-text',
@@ -933,7 +948,7 @@ module.exports = {
   },
   'report-person-study-phone': {
     className: ['govuk-input', 'govuk-input--width-20'],
-    validate: [{ type: 'maxlength', arguments: 20 }]
+    validate: ['required', { type: 'maxlength', arguments: 20 }]
   },
   'report-person-study-email': {
     validate: ['email', { type: 'maxlength', arguments: 100 }]
@@ -1189,7 +1204,7 @@ module.exports = {
   },
   'company-phone': {
     className: ['govuk-input', 'govuk-input--width-20'],
-    validate: [{ type: 'maxlength', arguments: 20 }]
+    validate: ['required', { type: 'maxlength', arguments: 20 }]
   },
   'company-email': {
     formatter: ['removespaces'],

--- a/apps/paf/index.js
+++ b/apps/paf/index.js
@@ -14,6 +14,7 @@ const addressFormatter = require('./behaviours/address-formatter');
 const additionalPersonFormatter = require('./behaviours/additional-person-formatter');
 const vehicleToggleFormatter = require('./behaviours/vehicle-toggle-formatter');
 const SendToSQS = require('./behaviours/send-to-sqs');
+const UnsetCrimeCountry = require('./behaviours/unset-crime-country');
 
 module.exports = {
   name: 'paf',
@@ -257,7 +258,8 @@ module.exports = {
           field: 'crime-location',
           value: 'yes'
         }
-      }]
+      }],
+      behaviours: [UnsetCrimeCountry]
     },
     '/crime-another-location': {
       fields: ['crime-another-location',

--- a/apps/paf/translations/src/en/validation.json
+++ b/apps/paf/translations/src/en/validation.json
@@ -93,12 +93,19 @@
     "maxlength": "You can't use more than {{maxlength}} characters for your answer"
   },
   "crime-location-phone": {
+    "required": "Enter a valid phone number",
+    "maxlength": "You can't use more than {{maxlength}} characters for your answer"
+  },
+
+  "report-person-study-phone": {
+    "required": "Enter a valid phone number",
     "maxlength": "You can't use more than {{maxlength}} characters for your answer"
   },
   "crime-another-location-address-postcode": {
     "maxlength": "You can't use more than {{maxlength}} characters for your answer"
   },
   "crime-another-location-phone": {
+    "required": "Enter a valid phone number",
     "maxlength": "You can't use more than {{maxlength}} numbers for your answer"
   },
   "report-person-first-name": {
@@ -130,6 +137,7 @@
     "maxlength": "You can't use more than {{maxlength}} characters for your answer"
   },
   "report-person-location-phone": {
+    "required": "Enter a valid phone number",
     "maxlength": "You can't use more than {{maxlength}} characters for your answer"
   },
   "report-person-location-email": {
@@ -156,6 +164,11 @@
     "maxlength": "You can't use more than {{maxlength}} characters for your answer"
   },
   "report-person-occupation-company-phone": {
+    "required": "Enter a valid phone number",
+    "maxlength": "You can't use more than {{maxlength}} characters for your answer"
+  },
+  "company-phone": {
+    "required": "Enter a valid phone number",
     "maxlength": "You can't use more than {{maxlength}} characters for your answer"
   },
   "report-person-occupation-company-manager": {
@@ -276,5 +289,33 @@
   },
   "when-to-contact": {
     "maxlength": "You can't use more than {{maxlength}} characters for your answer"
+  },
+  "boat-country-departure": {
+    "required": "Enter a valid country",
+    "notUrl": "Enter a valid country on the list"
+  },
+  "airline-country-departure": {
+    "required": "Enter a valid country",
+    "notUrl": "Enter a valid country on the list"
+  },
+  "crime-location-country": {
+    "required": "Enter a valid country",
+    "notUrl": "Enter a valid country on the list"
+  },
+  "crime-another-location-country": {
+    "required": "Enter a valid country",
+    "notUrl": "Enter a valid country on the list"
+  },
+  "train-country-departure": {
+    "required": "Enter a valid country",
+    "notUrl": "Enter a valid country on the list"
+  },
+  "report-person-location-outside-uk-address-country": {
+    "required": "Enter a valid country",
+    "notUrl": "Enter a valid country on the list"
+  },
+  "report-person-location-travel-to-uk-country": {
+    "required": "Enter a valid country",
+    "notUrl": "Enter a valid country on the list"
   }
 }


### PR DESCRIPTION
## What?
[PAF-128](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-128) Country' fields allow any text 
[PAF-129](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-129)- All 'Country' fields allow any text without the use of drop down list
## Why?
remove any url from the input text and accept validation entry.
this validation with control the textbox for both country and phone numbers
## How?

- added validation attribute in the field/index.js file 
- added validation message in the validation.js file

## Testing?
Manual testing via UI
## Screenshots (optional)
## Anything Else? (optional)
