### PR TITLE
PAF-132 Gender-unknown fix

### DIFF
--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -1346,7 +1346,7 @@ module.exports = {
       'male',
       'female',
       'other',
-      'gender-unknown'
+      'prefer-not-to-say'
     ]
   },
   'about-you-contact': {

--- a/apps/paf/translations/src/en/fields.json
+++ b/apps/paf/translations/src/en/fields.json
@@ -1333,8 +1333,8 @@
       "other": {
         "label": "Other"
       },
-      "gender-unknown": {
-        "label": "I don't know"
+      "prefer-not-to-say": {
+        "label": "Prefer not to say"
       }
     }
   },

--- a/lib/ims-hof-values-map.json
+++ b/lib/ims-hof-values-map.json
@@ -305,6 +305,10 @@
              "IMS": "DontKnow"
             },
             {
+            "HOF": "prefer-not-to-say",
+            "IMS": "DontKnow"
+            },
+            {
              "HOF": "uk",
              "IMS": "IntheUK"
             },


### PR DESCRIPTION
## What?
What is your gender?' last option is shown as 'I don't know' but should be 'Prefer not to say'.  - [PAF-132](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-132)

## Why?
Part of PAF requirement

## How?
- Changed gender-unknown options to prefer-not-to-say for report-person-gender, personAddGender and about-you-gender  fields  in fields/index.js
- Label changed from I don't know to Prefer not to say  for report-person-gender, personAddGender and about-you-gender  fields  in fields.json
- Changed values for HOF -key from gender-unknown to prefer-not-to-say in ims-hof-values-map.json

## Testing?
Testing passing  locally

## Anything else
Confirmed with DM. As long as prefer not to say is on the frontend, don't know is fine in IMS as we 'don't know' the gender. As long as we document it, so we know what we did when we move from IMS to IPM later in the year. If it's an issue then, we can change it.