### PR TITLE
PAF-178 Fix option not showing correct format on 'When will crime happen?'  page

### DIFF
--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -125,7 +125,7 @@ module.exports = {
     options: [
       'next-twenty-four-hours',
       'more-than-twenty-four-hours',
-      'unknown'
+      'when-will-crime-happen-unknown'
     ]
   },
   'date-crime-will-happen': dateComponent('date-crime-will-happen', {


### PR DESCRIPTION
## What?
Option not showing correct format on 'When will crime happen?' Page   - [PAF-178](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-178)

## Why?
In When will crime happen?' page  the third option is not showing correct format

## How?
In index.js in fields  the third option in when-will-crime-happen was changed to when-will-crime-happen-unknown from unknown

## Testing?
Testing pass locally
