### PR TITLE
PAF-177 Validation for date of birth bug fix

### DIFF
--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -17,6 +17,7 @@ function lettersAndSpacesOnly(value) {
 }
 const moment = require('moment');
 const PRETTY_DATE_FORMAT = 'Do MMMM YYYY';
+const after1900Validator = { type: 'after', arguments: ['1900'] };
 
 module.exports = {
   'crime-type': {
@@ -1327,7 +1328,8 @@ module.exports = {
   },
   'about-you-dob': dateComponent('about-you-dob', {
     isPageHeading: true,
-    mixin: 'input-date'
+    mixin: 'input-date',
+    validate: ['before', after1900Validator]
   }),
   'about-you-nationality': {
     isPageHeading: true,

--- a/apps/paf/translations/src/en/validation.json
+++ b/apps/paf/translations/src/en/validation.json
@@ -271,6 +271,11 @@
   "how-do-you-know-the-person": {
     "maxlength": "You can't use more than {{maxlength}} characters for your answer"
   },
+  "about-you-dob": {
+    "date": "Please enter a valid date",
+    "before": "Enter a date in the past",
+    "after": "Enter a date after 01 01 1900"
+  },
   "contact-number": {
     "maxlength": "You can't use more than {{maxlength}} characters for your answer"
   },


### PR DESCRIPTION
## What?
Missing Validation  - What is your date of birth? Page - [PAF-177](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-177)

## Why?
When the validation was triggered the message was missing

## How?
- Added validation for  'before', after1900Validator in about-you-dob  fields  in fields/index.js
- Validation messages added for  date,  before and after in validation.json
 
## Testing?
Testing passing  locally
