### PR TITLE
PAF-131: Fix bug where accessibility statement link navigates to page not found page

### DIFF
--- a/hof.settings.json
+++ b/hof.settings.json
@@ -10,5 +10,6 @@
   ],
   "session": {
     "name": "paf.hof.sid"
-  }
+  },
+  "getAccessibility": true
 }

--- a/test/_unit/server.spec.js
+++ b/test/_unit/server.spec.js
@@ -54,7 +54,8 @@ describe('Server.js app file', () => {
           appsPafStub
         ],
         behaviours: [ behavioursSetNavigationSectionStub],
-        session: { name: 'paf.hof.sid' }
+        session: { name: 'paf.hof.sid' },
+        getAccessibility: true
       });
     });
 


### PR DESCRIPTION
## What?
  [PAF-131](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-131) Fix bug to display accessibility statement link when user click.

## Why?
On click  Accessibility statement link navigates to page not found page

## How?
on hof.setting.json file , i have set getAccessibility to true 

## Testing?

- done a manual test for the task

- added line to unit testing to pass on drone 

## Screenshots (optional)
## Anything Else? (optional)
