### PR TITLE
PAF-134  Future date is accepted on the person date of birth bug fix

### DIFF
--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -16,6 +16,7 @@ function lettersAndSpacesOnly(value) {
   return /^[A-Za-z\s]*$/.test(value);
 }
 const moment = require('moment');
+const after1900Validator = { type: 'after', arguments: ['1900'] };
 const PRETTY_DATE_FORMAT = 'Do MMMM YYYY';
 
 module.exports = {
@@ -665,7 +666,8 @@ module.exports = {
   },
   'report-person-dob': dateComponent('report-person-dob', {
     isPageHeading: true,
-    mixin: 'input-date'
+    mixin: 'input-date',
+    validate: ['before', after1900Validator]
   }),
   'report-person-age-range': {
     mixin: 'radio-group',
@@ -1115,6 +1117,7 @@ module.exports = {
   personAddDob: dateComponent('personAddDob', {
     isPageHeading: true,
     mixin: 'input-date',
+    validate: ['before', after1900Validator],
     parse: d => d && moment(d).format(PRETTY_DATE_FORMAT)
   }),
   personAddAgeRange: {

--- a/apps/paf/translations/src/en/validation.json
+++ b/apps/paf/translations/src/en/validation.json
@@ -113,6 +113,11 @@
     "maxlength": "You can't use more than {{maxlength}} letters for your answer",
     "lettersAndSpacesOnly": "You can only use letters and spaces in your answer"
   },
+  "report-person-dob": {
+    "date": "Please enter a valid date",
+    "before": "Enter a date in the past",
+    "after": "Enter a date after 01 01 1900"
+  },
   "report-person-place-of-birth": {
     "maxlength": "You can't use more than {{maxlength}} letters for your answer",
     "lettersAndSpacesOnly": "You can only use letters and spaces in your answer. If you do not know this information, please leave this field blank"
@@ -224,6 +229,11 @@
   "personAddNickname": {
     "maxlength": "You can't use more than {{maxlength}} characters for your answer",
     "lettersAndSpacesOnly": "You can only use letters and spaces in your answer"
+  },
+  "personAddDob": {
+    "date": "Please enter a valid date",
+    "before": "Enter a date in the past",
+    "after": "Enter a date after 01 01 1900"
   },
   "personAddPassport": {
     "maxlength": "You can't use more than {{maxlength}} characters for your answer"


### PR DESCRIPTION
## What?
Missing Validation for future date - Future date is accepted on the person date of birth Page - [PAF-134](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-134)

## Why?
When the validation was triggered the message was missing for future date

## How?
- Validation added for report person dob and person person add dob   for future date filelds in index.js
- Validation messages added for report person dob and person add dob for future date in validation.json
 
## Testing?
Testing passing  locally
