### PR TITLE
PAF-74 Allow attachment URLs into SQS payload

### DIFF
--- a/lib/add-allegation-data.js
+++ b/lib/add-allegation-data.js
@@ -7,12 +7,12 @@ const valuesMap = require('./ims-hof-values-map.json');
 const eform = {
   EformFields: [],
   AdditionalPeople: [],
-  Attachements: []
+  Attachments: []
 };
 
 const addFieldToEform = (fieldName, fieldValue) => {
   if (fieldName === 'images') {
-    eform.Attachements.push({url: fieldValue});
+    eform.Attachments = fieldValue;
   } else if (fieldName === 'txpermoreallholder') {
     eform.AdditionalPeople.push({FieldName: fieldName, FieldValue: fieldValue});
   } else {
@@ -31,7 +31,6 @@ const addField = (name, value) => {
     }
   }
   if (name === 'images') {
-    console.log('Value :: ', value);
     addFieldToEform(name, value);
   }
 };
@@ -43,7 +42,7 @@ const addGroup = value  => {
 const addAllegationData = data => {
   Object.entries(data).forEach(entry => {
     const [key, value] = entry;
-    if (value !== '' && key !== 'images') {
+    if (value !== '') {
       if (key.includes('group')) {
         const groups = Array.isArray(value) ? value : value.split(',');
         groups.map(addGroup);

--- a/test/_unit/behaviours/add-allegation-data.spec.js
+++ b/test/_unit/behaviours/add-allegation-data.spec.js
@@ -15,10 +15,10 @@ describe("apps/lib 'add-allegation-data' behaviour should ", () => {
       addAllegationDataWithAdditionalPerAndFileRes = addAllegationData(dataWithAdditionalPersonAndFile);
     });
 
-    it('addAlligationData response have EformFields, AdditionalPeople, Attachements', () => {
+    it('addAlligationData response have EformFields, AdditionalPeople, Attachments', () => {
       JSON.parse(addAllegationDataWithAdditionalPerAndFileRes).should.have.property('EformFields');
       JSON.parse(addAllegationDataWithAdditionalPerAndFileRes).should.have.property('AdditionalPeople');
-      JSON.parse(addAllegationDataWithAdditionalPerAndFileRes).should.have.property('Attachements');
+      JSON.parse(addAllegationDataWithAdditionalPerAndFileRes).should.have.property('Attachments');
     });
 
     it('addAlligationData contain rdpermoreinfomore set to true when Additional person is selected', () => {


### PR DESCRIPTION
## What?

Altered behaviour as part of form submission to allow file-vault URLs for attachments to be added from the session into the SQS payload and sent to queue.

Removed an unnecessary log of image array. This comes up in other logs elsewhere in the behaviour.

## Why?

Existing code was blocking this. Will be a prerequisite to sending the attachment files to IMS from the ims-resolver.

## How?

Removed existing conditionals that stopped the array of file-vault URLs for attachements/uploaded files from being brought from the session into the SQS payload.

Altered the tree structure so it will be simpler to extract the file URL array from the payload for processing in the ims-resolver.

## Testing?

Tested locally using the UAT queue.
