### PR TITLE
PAF-134-validator-patch

### DIFF
--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -18,7 +18,6 @@ function lettersAndSpacesOnly(value) {
 const moment = require('moment');
 const after1900Validator = { type: 'after', arguments: ['1900'] };
 const PRETTY_DATE_FORMAT = 'Do MMMM YYYY';
-const after1900Validator = { type: 'after', arguments: ['1900'] };
 
 module.exports = {
   'crime-type': {


### PR DESCRIPTION
## What?

PAF-134-validator patch

## Why?

Existing code shows lint error  due to after1900Validator which appeared twice in fields index.js

## How?

Removed after1900Validator in fields index.js which appeared twice

## Testing?

Tested locally