### PR TITLE
PAF-179 request entity too large error bug fix

### DIFF
--- a/apps/paf/behaviours/save-file.js
+++ b/apps/paf/behaviours/save-file.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const _ = require('lodash');
+const config = require('../../../config');
 const Model = require('../models/file-upload');
+const fileSizeNum = size => size.match(/\d+/g)[0];
 
 module.exports = name => superclass => class extends superclass {
   process(req) {
@@ -20,7 +22,41 @@ module.exports = name => superclass => class extends superclass {
     if (!Object.keys(req.form.errors).length) {
       req.form.values['other-info-file-upload'] = null;
     }
-    return super.locals(req, res, next);
+    const maxNum = fileSizeNum(config.upload.maxFileSize);
+    const maxSize = config.upload.maxFileSize.match(/[a-zA-Z]+/g)[0].toUpperCase();
+    return Object.assign({}, super.locals(req, res, next), {
+      maxFileSize: `${maxNum} ${maxSize}`
+    });
+  }
+
+  validateField(key, req) {
+    if (req.form.values['other-info-file-upload']) {
+      const fileUpload = _.get(req.files, `${name}`);
+      if (fileUpload) {
+        const uploadSize = fileUpload.size;
+        const mimetype = fileUpload.mimetype;
+        const uploadSizeTooBig = uploadSize > (fileSizeNum(config.upload.maxFileSize) * 1000000);
+        const uploadSizeBeyondServerLimits = uploadSize === null;
+        const invalidMimetype = !config.upload.allowedMimeTypes.includes(mimetype);
+        const invalidSize = uploadSizeTooBig || uploadSizeBeyondServerLimits;
+
+        if (invalidSize || invalidMimetype) {
+          return new this.ValidationError(key, {
+            key,
+            type: invalidSize ? 'maxFileSize' : 'fileType',
+            redirect: undefined
+          });
+        }
+      } else {
+        return new this.ValidationError(key, {
+          key,
+          type: 'required',
+          redirect: undefined
+        });
+      }
+    }
+
+    return super.validateField(key, req);
   }
 
   saveValues(req, res, next) {

--- a/apps/paf/translations/src/en/validation.json
+++ b/apps/paf/translations/src/en/validation.json
@@ -291,5 +291,9 @@
   },
   "when-to-contact": {
     "maxlength": "You can't use more than {{maxlength}} characters for your answer"
+  },
+  "other-info-file-upload": {
+    "maxFileSize": "Select a file that is smaller than 100 MB",
+    "fileType": "This file is not a valid file format you can upload to this service."
   }
 }

--- a/config.js
+++ b/config.js
@@ -13,6 +13,32 @@ module.exports = {
   useMocks: useMocks,
   upload: {
     maxFileSize: '100mb',
+    allowedMimeTypes: [
+      'application/json',
+      'application/msword',
+      'application/pdf',
+      'application/rtf',
+      'application/vnd.ms-excel',
+      'application/vnd.ms-outlook',
+      'application/vnd.ms-powerpoint',
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.template',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'application/xml',
+      'application/x-tika-ooxml',
+      'audio/vnd.wave',
+      'audio/wav',
+      'audio/x-wav',
+      'image/bmp',
+      'image/jpeg',
+      'image/jpg',
+      'image/png',
+      'message/rfc822',
+      'text/csv',
+      'text/plain',
+      'text/xml'
+    ],
     // if mocks set use file service served up by app otherwise use filevault's port 3000
     hostname: !useMocks && process.env.FILE_VAULT_URL ?
       process.env.FILE_VAULT_URL :


### PR DESCRIPTION
## What?

PAF-179 request entity too large error bug fix 

## Why?

Max filesize error not shown properly when we upload large files >100mb

## How?
- fileSizeNum, maxSize and maxNum constants added in save-file.js
- validateFiled(key, req) method added in save-file.js
- Validation messages added to validation.json
- Allowed mime types added to config.js


## Testing?

Tests passing locally

