### PR TITLE
PAF-195 Replaced spelling error on UI

### DIFF
--- a/apps/paf/behaviours/set-transport-toggle.js
+++ b/apps/paf/behaviours/set-transport-toggle.js
@@ -13,7 +13,7 @@ module.exports = superclass => class extends superclass {
       locals.hgvFChecked = true;
     } else if (req.form.values['crime-hgv-group'] === 'hgv-hard-sided') {
       locals.hgvHSChecked = true;
-    } else if (req.form.values['crime-hgv-group'] === 'hgv-refridgerated') {
+    } else if (req.form.values['crime-hgv-group'] === 'hgv-refrigerated') {
       locals.hgvRChecked = true;
     } else if (req.form.values['crime-hgv-group'] === 'hgv-tanker') {
       locals.hgvTChecked = true;
@@ -61,7 +61,7 @@ module.exports = superclass => class extends superclass {
       locals.personHgvFChecked = true;
     } else if (req.form.values['report-person-transport-hgv-group'] === 'hgv-hard-sided') {
       locals.personHgvHSChecked = true;
-    } else if (req.form.values['report-person-transport-hgv-group'] === 'hgv-refridgerated') {
+    } else if (req.form.values['report-person-transport-hgv-group'] === 'hgv-refrigerated') {
       locals.personHgvRChecked = true;
     } else if (req.form.values['report-person-transport-hgv-group'] === 'hgv-tanker') {
       locals.personHgvTChecked = true;

--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -243,7 +243,7 @@ module.exports = {
       'hgv-canvas-sided',
       'hgv-flatbed',
       'hgv-hard-sided',
-      'hgv-refridgerated',
+      'hgv-refrigerated',
       'hgv-tanker'
     ],
     dependent: {
@@ -1026,7 +1026,7 @@ module.exports = {
       'hgv-canvas-sided',
       'hgv-flatbed',
       'hgv-hard-sided',
-      'hgv-refridgerated',
+      'hgv-refrigerated',
       'hgv-tanker'
     ],
     dependent: {

--- a/apps/paf/translations/src/en/fields.json
+++ b/apps/paf/translations/src/en/fields.json
@@ -233,8 +233,8 @@
       "hgv-hard-sided": {
         "label": "HGV hard sided"
       },
-      "hgv-refridgerated": {
-        "label": "HGV refridgerated"
+      "hgv-refrigerated": {
+        "label": "HGV refrigerated"
       },
       "hgv-tanker": {
         "label": "HGV tanker"
@@ -1022,8 +1022,8 @@
       "hgv-hard-sided": {
         "label": "HGV hard sided"
       },
-      "hgv-refridgerated": {
-        "label": "HGV refridgerated"
+      "hgv-refrigerated": {
+        "label": "HGV refrigerated"
       },
       "hgv-tanker": {
         "label": "HGV tanker"

--- a/apps/paf/views/partials/crime-hgv-group.html
+++ b/apps/paf/views/partials/crime-hgv-group.html
@@ -20,9 +20,9 @@
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="crime-hgv-group" id="crime-hgv-group-hgv-refridgerated"  value="hgv-refridgerated" {{#hgvRChecked}}checked="checked"{{/hgvRChecked}}>
-        <label class="govuk-label govuk-radios__label" for="crime-hgv-group-hgv-refridgerated">
-          {{#t}}fields.crime-hgv-group.options.hgv-refridgerated{{/t}}
+        <input class="govuk-radios__input"  type="radio" name="crime-hgv-group" id="crime-hgv-group-hgv-refrigerated"  value="hgv-refrigerated" {{#hgvRChecked}}checked="checked"{{/hgvRChecked}}>
+        <label class="govuk-label govuk-radios__label" for="crime-hgv-group-hgv-refrigerated">
+          {{#t}}fields.crime-hgv-group.options.hgv-refrigerated{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">

--- a/apps/paf/views/partials/report-person-transport-hgv-group.html
+++ b/apps/paf/views/partials/report-person-transport-hgv-group.html
@@ -20,9 +20,9 @@
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input"  type="radio" name="report-person-transport-hgv-group" id="report-person-transport-hgv-group-hgv-refridgerated"  value="hgv-refridgerated" {{#personHgvRChecked}}checked="checked"{{/personHgvRChecked}}>
-        <label class="govuk-label govuk-radios__label" for="report-person-transport-hgv-group-hgv-refridgerated">
-          {{#t}}fields.report-person-transport-hgv-group.options.hgv-refridgerated{{/t}}
+        <input class="govuk-radios__input"  type="radio" name="report-person-transport-hgv-group" id="report-person-transport-hgv-group-hgv-refrigerated"  value="hgv-refrigerated" {{#personHgvRChecked}}checked="checked"{{/personHgvRChecked}}>
+        <label class="govuk-label govuk-radios__label" for="report-person-transport-hgv-group-hgv-refrigerated">
+          {{#t}}fields.report-person-transport-hgv-group.options.hgv-refrigerated{{/t}}
         </label>
       </div>
       <div class="govuk-radios__item">

--- a/lib/ims-hof-values-map.json
+++ b/lib/ims-hof-values-map.json
@@ -161,7 +161,7 @@
              "IMS": "vehicle_type.HGVHardsided"
             },
             {
-             "HOF": "hgv-refridgerated",
+             "HOF": "hgv-refrigerated",
              "IMS": "vehicle_type.HGVRef"
             },
             {

--- a/test/_unit/behaviours/set-transport-toggle.spec.js
+++ b/test/_unit/behaviours/set-transport-toggle.spec.js
@@ -39,8 +39,8 @@ describe('apps/paf/behaviours/set-transport-toggle', () => {
         req.form.values['crime-hgv-group'] = 'hgv-hard-sided';
         controller.locals(req, res).should.have.property('hgvHSChecked').and.deep.equal(true);
       });
-      it('locals should have hgvRChecked property as true if hgv refridgerated has been selected', () => {
-        req.form.values['crime-hgv-group'] = 'hgv-refridgerated';
+      it('locals should have hgvRChecked property as true if hgv refrigerated has been selected', () => {
+        req.form.values['crime-hgv-group'] = 'hgv-refrigerated';
         controller.locals(req, res).should.have.property('hgvRChecked').and.deep.equal(true);
       });
       it('locals should have hgvTCheckedproperty as true if hgv tanker has been selected', () => {
@@ -126,8 +126,8 @@ describe('apps/paf/behaviours/set-transport-toggle', () => {
         req.form.values['report-person-transport-hgv-group'] = 'hgv-hard-sided';
         controller.locals(req, res).should.have.property('personHgvHSChecked').and.deep.equal(true);
       });
-      it('locals should have personHgvRChecked property as true if hgv refridgerated has been selected', () => {
-        req.form.values['report-person-transport-hgv-group'] = 'hgv-refridgerated';
+      it('locals should have personHgvRChecked property as true if hgv refrigerated has been selected', () => {
+        req.form.values['report-person-transport-hgv-group'] = 'hgv-refrigerated';
         controller.locals(req, res).should.have.property('personHgvRChecked').and.deep.equal(true);
       });
       it('locals should have personHgvTChecked property as true if hgv tanker has been selected', () => {


### PR DESCRIPTION
## What?
[PAF-195](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-195) 
## Why?
Wrong Spelling - 'What is the vehicle type?' - 'HGV refridgerated' changed to HGV refrigerated'
## How?
 - Replace the spelling error in 
 > apps/paf/translations/src/en/fields.json 
 > apps/paf/views/partials/report-person-transport-hgv-group.html
 > lib/ims-hof-values-map.json
 > apps/paf/behaviours/set-transport-toggle.js
 > apps/paf/fields/index.js
 > test/_unit/behaviours/set-transport-toggle.spec.js
## Testing?
Tested manually
## Screenshots (optional)
![Screenshot 2024-01-18 at 12 59 14](https://github.com/UKHomeOffice/paf/assets/138882912/f06c9ec1-ba53-48b7-a824-479c1b3f4800)
## Anything Else? (optional)
