### PR TITLE
PAF-197 Question label is different from the wire-frame

### DIFF
--- a/apps/paf/translations/src/en/pages.json
+++ b/apps/paf/translations/src/en/pages.json
@@ -3,7 +3,7 @@
     "header": "Tell us the time and date the crime will happen, if you know them"
   },
   "when-will-crime-happen-more-info": {
-    "header": "If you have any more information about when the crime happening please tell us here:"
+    "header": "If you have any more information about when it is happening please tell us here:"
   },
   "crime-transport-vehicle-details": {
     "header": "What are the vehicle details?"


### PR DESCRIPTION
## What?
[PAF-197](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-197) Paf-when-will-crime-happen-more-info - Question is different to wire-frame design document
## Why?
Question is different to wire-frame design document
## How?
Changed the label header in page.json file 
## Testing?
Tested manually
## Screenshots (optional)
![Screenshot 2024-01-18 at 13 42 46](https://github.com/UKHomeOffice/paf/assets/138882912/9e5d03dc-0de2-44b3-bd94-e9db2824c31d)

## Anything Else? (optional)
