### PR TITLE
PAF-61 Update ims-resolver deployment to use branch image

### DIFF
--- a/kube/ims-resolver/ims-resolver-deploy.yml
+++ b/kube/ims-resolver/ims-resolver-deploy.yml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: ims-resolver
-          image: quay.io/ukhomeofficedigital/ims-resolver:68b6b033bdcef021307308021f0ad288a685879c
+          image: quay.io/ukhomeofficedigital/ims-resolver:91979bf3dd2eabee61f1b01385e07bba8e518abc
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/kube/ims-resolver/ims-resolver-deploy.yml
+++ b/kube/ims-resolver/ims-resolver-deploy.yml
@@ -39,14 +39,14 @@ spec:
     spec:
       containers:
         - name: ims-resolver
-          image: quay.io/ukhomeofficedigital/ims-resolver:cf0d3271dc2e851583f2d2f15f62af334ddbacf8
+          image: quay.io/ukhomeofficedigital/ims-resolver:68b6b033bdcef021307308021f0ad288a685879c
           imagePullPolicy: Always
           envFrom:
             - configMapRef:
                 {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
                 name: {{ .APP_NAME }}-configmap-{{ .DRONE_SOURCE_BRANCH }}
                 {{ else }}
-                name: configmap
+                name: {{ .APP_NAME }}-configmap
                 {{ end }}
           env:
             - name: TZ
@@ -71,6 +71,26 @@ spec:
                 secretKeyRef:
                   name: ims-credentials
                   key: ims_endpoint
+            - name: KEYCLOAK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-client
+                  key: secret
+            - name: KEYCLOAK_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-client
+                  key: id
+            - name: KEYCLOAK_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-user
+                  key: username
+            - name: KEYCLOAK_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-user
+                  key: password
             {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
             - name: NODE_TLS_REJECT_UNAUTHORIZED
               value: "0"


### PR DESCRIPTION
## What?

* Add image containing PAF-61 changes to IMS-resolver deployment
* Update the IMS-resolver env to pull in the correct configmap for UAT
* Add Keycloak variables to IMS resolver deployment env from secret

## Why?

This PR allows PAF to deploy with [changes made to IMS-resolver for PAF-61](https://github.com/UKHomeOffice/ims-resolver/pull/17)

IMS-resolver requires Keycloak secrets to authenticate when retrieving uploaded documents to pass on to IMS via file-vault.

Previously the deployment was pulling the wrong configmap into UAT for ims-resolver. This should be fixed with this update too.

## Testing?

Can be tested in branch once the pull request triggers a deployment
