### PR TITLE
Fix discrepancies between fv URLs across deployments and ingress (UAT/STG/PROD)

### DIFF
--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -130,7 +130,7 @@ spec:
             {{ end }}
             - name: FILE_VAULT_URL
             {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-              value: https://fv.{{ .APP_NAME }}.homeoffice.gov.uk/file
+              value: https://fv-paf.sas.homeoffice.gov.uk/file
             {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
               value: https://fv-paf.stg.sas.homeoffice.gov.uk/file
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -54,11 +54,11 @@ spec:
               value: "0"
             - name: FILE_VAULT_URL
             {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-              value: https://fv.prod.{{ .APP_NAME }}.homeoffice.gov.uk
+              value: fv-paf.sas.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
-              value: https://fv-stg.prod.{{ .APP_NAME }}.homeoffice.gov.uk
+              value: fv-paf.stg.sas.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
-              value: https://fv-uat.notprod.{{ .APP_NAME }}.homeoffice.gov.uk
+              value: fv-paf.uat.sas-notprod.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
               value: https://fv-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
             - name: DEBUG
@@ -115,11 +115,11 @@ spec:
                   key: id
             - name: PROXY_REDIRECTION_URL
             {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-              value: https://fv.prod.{{ .APP_NAME }}.homeoffice.gov.uk
+              value: fv-paf.sas.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
-              value: https://fv-stg.prod.{{ .APP_NAME }}.homeoffice.gov.uk
+              value: fv-paf.stg.sas.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
-              value: https://fv-uat.notprod.{{ .APP_NAME }}.homeoffice.gov.uk
+              value: fv-paf.uat.sas-notprod.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
               value: https://fv-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
             {{ end }}

--- a/kube/file-vault/file-vault-ingress.yml
+++ b/kube/file-vault/file-vault-ingress.yml
@@ -22,7 +22,7 @@ spec:
       {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
       - fv-paf.stg.sas.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .PROD_ENV }}
-      - fv-paf.homeoffice.gov.uk
+      - fv-paf.sas.homeoffice.gov.uk
       {{ end }}
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
       secretName: branch-tls-external
@@ -37,7 +37,7 @@ spec:
     {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
     - host: fv-paf.stg.sas.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .PROD_ENV }}
-    - host: fv-paf.homeoffice.gov.uk
+    - host: fv-paf.sas.homeoffice.gov.uk
     {{ end }}
       http:
         paths:


### PR DESCRIPTION
## What?

Edited references to FILE_VAULT_URL across deployments for PAF app and file-vault so that they all use the same URL
Also updated the file-vault ingress file so that the format matches other contemporary forms.

## Why?

QAT team were unable to retrieve uploaded files in the UAT environment due to a mismatch of URLs causing incorrect redirection from filevault login, or incorrect logging of retrieval URLs causing a page not found error.

## How?

Updated conditional variable declaration in deployment and ingress files.

## Testing?

This will not be possible to test until it has reached UAT environment.

