### PR TITLE
Filevault URL fix update: URLs must be https

### DIFF
--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -54,11 +54,11 @@ spec:
               value: "0"
             - name: FILE_VAULT_URL
             {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-              value: fv-paf.sas.homeoffice.gov.uk
+              value: https://fv-paf.sas.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
-              value: fv-paf.stg.sas.homeoffice.gov.uk
+              value: https://fv-paf.stg.sas.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
-              value: fv-paf.uat.sas-notprod.homeoffice.gov.uk
+              value: https://fv-paf.uat.sas-notprod.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
               value: https://fv-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
             - name: DEBUG
@@ -115,11 +115,11 @@ spec:
                   key: id
             - name: PROXY_REDIRECTION_URL
             {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-              value: fv-paf.sas.homeoffice.gov.uk
+              value: https://fv-paf.sas.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
-              value: fv-paf.stg.sas.homeoffice.gov.uk
+              value: https://fv-paf.stg.sas.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
-              value: fv-paf.uat.sas-notprod.homeoffice.gov.uk
+              value: https://fv-paf.uat.sas-notprod.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
               value: https://fv-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
             {{ end }}


### PR DESCRIPTION
## What?

Updated `file-vault-deployment.yml` to fix an issue causing the pod to fail to deploy in UAT

## Why?

Following recent merged PR #122 The file-vault pod cannot start because the file-vault reverse proxy requires a https/TLS address to connect to. The prefixing of `https://` to the previous update was not done by mistake. This PR fixes that error.

## How?

Updated deployment to add https to conditional URL declaration
