### PR TITLE
PAF-196-Added dropdown menu to select hour and minutes

### DIFF
--- a/apps/paf/behaviours/time-crime-happened.js
+++ b/apps/paf/behaviours/time-crime-happened.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const _ = require('lodash');
+
+module.exports = superclass => class extends superclass {
+  
+  saveValues(req, res, next) {
+    const hour = req.form.values['time-crime-will-happen-hour'];
+    const minute = req.form.values['time-crime-will-happen-minutes'];
+
+    req.sessionModel.set('time-crime-will-happen',`${hour}:${minute}`)
+
+    return super.saveValues(req,res,next);
+  }
+};

--- a/apps/paf/data/hour.json
+++ b/apps/paf/data/hour.json
@@ -1,0 +1,98 @@
+[
+    {
+        "value": "00",
+        "label": "00"
+    },
+    {
+        "value": "01",
+        "label": "01"
+    },
+    {
+        "value": "02",
+        "label": "02"
+    },
+    {
+        "value": "03",
+        "label": "03"
+    },
+    {
+        "value": "04",
+        "label": "04"
+    },
+    {
+        "value": "05",
+        "label": "05"
+    },
+    {
+        "value": "06",
+        "label": "06"
+    },
+    {
+        "value": "07",
+        "label": "07"
+    },
+    {
+        "value": "08",
+        "label": "08"
+    },
+    {
+        "value": "09",
+        "label": "09"
+    },
+    {
+        "value": "10",
+        "label": "10"
+    },
+    {
+        "value": "11",
+        "label": "11"
+    },
+    {
+        "value": "12",
+        "label": "12"
+    },
+    {
+        "value": "13",
+        "label": "13"
+    },
+    {
+        "value": "14",
+        "label": "14"
+    },
+    {
+        "value": "15",
+        "label": "15"
+    },
+    {
+        "value": "16",
+        "label": "16"
+    },
+    {
+        "value": "17",
+        "label": "17"
+    },
+    {
+        "value": "18",
+        "label": "18"
+    },
+    {
+        "value": "19",
+        "label": "19"
+    },
+    {
+        "value": "20",
+        "label": "20"
+    },
+    {
+        "value": "21",
+        "label": "21"
+    },
+    {
+        "value": "22",
+        "label": "22"
+    },
+    {
+        "value": "23",
+        "label": "23"
+    }
+]

--- a/apps/paf/data/minutes.json
+++ b/apps/paf/data/minutes.json
@@ -1,0 +1,242 @@
+[
+    {
+        "value": "00",
+        "label": "00"
+    },
+    {
+        "value": "01",
+        "label": "01"
+    },
+    {
+        "value": "02",
+        "label": "02"
+    },
+    {
+        "value": "03",
+        "label": "03"
+    },
+    {
+        "value": "04",
+        "label": "04"
+    },
+    {
+        "value": "05",
+        "label": "05"
+    },
+    {
+        "value": "06",
+        "label": "06"
+    },
+    {
+        "value": "07",
+        "label": "07"
+    },
+    {
+        "value": "08",
+        "label": "08"
+    },
+    {
+        "value": "09",
+        "label": "09"
+    },
+    {
+        "value": "10",
+        "label": "10"
+    },
+    {
+        "value": "11",
+        "label": "11"
+    },
+    {
+        "value": "12",
+        "label": "12"
+    },
+    {
+        "value": "13",
+        "label": "13"
+    },
+    {
+        "value": "14",
+        "label": "14"
+    },
+    {
+        "value": "15",
+        "label": "15"
+    },
+    {
+        "value": "16",
+        "label": "16"
+    },
+    {
+        "value": "17",
+        "label": "17"
+    },
+    {
+        "value": "18",
+        "label": "18"
+    },
+    {
+        "value": "19",
+        "label": "19"
+    },
+    {
+        "value": "20",
+        "label": "20"
+    },
+    {
+        "value": "21",
+        "label": "21"
+    },
+    {
+        "value": "22",
+        "label": "22"
+    },
+    {
+        "value": "23",
+        "label": "23"
+    },
+    {
+        "value": "24",
+        "label": "24"
+    },
+    {
+        "value": "25",
+        "label": "25"
+    },
+    {
+        "value": "26",
+        "label": "26"
+    },
+    {
+        "value": "27",
+        "label": "27"
+    },
+    {
+        "value": "28",
+        "label": "28"
+    },
+    {
+        "value": "29",
+        "label": "29"
+    },
+    {
+        "value": "30",
+        "label": "30"
+    },
+    {
+        "value": "31",
+        "label": "31"
+    },
+    {
+        "value": "32",
+        "label": "32"
+    },
+    {
+        "value": "33",
+        "label": "33"
+    },
+    {
+        "value": "34",
+        "label": "34"
+    },
+    {
+        "value": "35",
+        "label": "35"
+    },
+    {
+        "value": "36",
+        "label": "36"
+    },
+    {
+        "value": "37",
+        "label": "37"
+    },
+    {
+        "value": "38",
+        "label": "38"
+    },
+    {
+        "value": "39",
+        "label": "39"
+    },
+    {
+        "value": "40",
+        "label": "40"
+    },
+    {
+        "value": "41",
+        "label": "41"
+    },
+    {
+        "value": "42",
+        "label": "42"
+    },
+    {
+        "value": "43",
+        "label": "43"
+    },
+    {
+        "value": "44",
+        "label": "44"
+    },
+    {
+        "value": "45",
+        "label": "45"
+    },
+    {
+        "value": "46",
+        "label": "46"
+    },
+    {
+        "value": "47",
+        "label": "47"
+    },
+    {
+        "value": "48",
+        "label": "48"
+    },
+    {
+        "value": "49",
+        "label": "49"
+    },
+    {
+        "value": "50",
+        "label": "50"
+    },
+    {
+        "value": "51",
+        "label": "51"
+    },
+    {
+        "value": "52",
+        "label": "52"
+    },
+    {
+        "value": "53",
+        "label": "53"
+    },
+    {
+        "value": "54",
+        "label": "54"
+    },
+    {
+        "value": "55",
+        "label": "55"
+    },
+    {
+        "value": "56",
+        "label": "56"
+    },
+    {
+        "value": "57",
+        "label": "57"
+    },
+    {
+        "value": "58",
+        "label": "58"
+    },
+    {
+        "value": "59",
+        "label": "59"
+    }
+]

--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -3,6 +3,8 @@
 const nationalities = require('../data/nationalities');
 const _ = require('lodash');
 const countriesList = require('../data/countriesList');
+const hours = require('../data/hour');
+const minutes = require('../data/minutes');
 const trainCompanies = require('../data/trainCompanies');
 const airlineCompanies = require('../data/airlineCompanies');
 const occupation = require('../data/occupation');
@@ -132,8 +134,24 @@ module.exports = {
   'date-crime-will-happen': dateComponent('date-crime-will-happen', {
     mixin: 'input-date'
   }),
-  'time-crime-will-happen': {
-    mixin: 'input-text'
+  'time-crime-will-happen': {},
+  'time-crime-will-happen-hour': {
+    mixin: 'select',
+    className: ['js-hidden'],
+    options:
+      [{
+        value: '',
+        label: 'fields.hour.options.null'
+      }].concat(hours)
+  },
+  'time-crime-will-happen-minutes': {
+    mixin: 'select',
+    className: ['js-hidden'],
+    options:
+      [{
+        value: '',
+        label: 'fields.minutes.options.null'
+      }].concat(minutes)
   },
   'when-will-crime-happen-more-info': {
     mixin: 'textarea',

--- a/apps/paf/index.js
+++ b/apps/paf/index.js
@@ -15,6 +15,7 @@ const addressFormatter = require('./behaviours/address-formatter');
 const additionalPersonFormatter = require('./behaviours/additional-person-formatter');
 const vehicleToggleFormatter = require('./behaviours/vehicle-toggle-formatter');
 const SendToSQS = require('./behaviours/send-to-sqs');
+const timeCrimeBehaviour = require('./behaviours/time-crime-happened');
 
 module.exports = {
   name: 'paf',
@@ -60,8 +61,9 @@ module.exports = {
       }]
     },
     '/date-time-crime-will-happen': {
-      fields: ['date-crime-will-happen', 'time-crime-will-happen'],
-      next: '/when-will-crime-happen-more-info'
+      fields: ['date-crime-will-happen', 'time-crime-will-happen', 'time-crime-will-happen-hour', 'time-crime-will-happen-minutes'],
+      next: '/when-will-crime-happen-more-info',
+      behaviours: [timeCrimeBehaviour],
     },
     '/when-will-crime-happen-more-info': {
       fields: ['when-will-crime-happen-more-info'],

--- a/apps/paf/translations/src/en/fields.json
+++ b/apps/paf/translations/src/en/fields.json
@@ -1374,5 +1374,17 @@
   },
   "images": {
     "label": "Attachments"
+  },
+  "time-crime-will-happen-hour": {
+    "label": "Hour",
+    "options": {
+      "null": "hh"
+    }
+  },
+  "time-crime-will-happen-minutes": {
+    "label": "Minute",
+    "options": {
+      "null": "mm"
+    }
   }
 }

--- a/apps/paf/views/date-time-crime-will-happen.html
+++ b/apps/paf/views/date-time-crime-will-happen.html
@@ -1,0 +1,9 @@
+{{<partials-page}}
+   {{$page-content}}
+   {{#renderField}}date-crime-will-happen{{/renderField}}
+
+    {{>partials-time-component}}
+
+    {{#input-submit}}continue{{/input-submit}}
+   {{/page-content}}
+ {{/partials-page}}

--- a/apps/paf/views/partials/time-component.html
+++ b/apps/paf/views/partials/time-component.html
@@ -1,0 +1,7 @@
+
+
+<div class="time-view" >
+    <span> {{#select}}hour{{/select}}</span>
+    <span> - </span>
+    <span>{{#select}}minutes{{/select}}</span>
+</div>

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -231,3 +231,11 @@ pre.looped-records {
   word-break: break-all;
 }
 
+.time-view {
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+}
+.time-view span {
+  margin-right: 10px;
+}


### PR DESCRIPTION
## What?
[PAF-196](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-196) -[s Form](https://collaboration.homeoffice.gov.uk/jira/browse/PAF)[PAF-196](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-196)
Time (hh,mm)drop downs are missing from date-time-crime-will-happen page
## Why?
As described in the wire frame
## How?
- added fields properties in the index.js file (hour and minutes)
- create a behaviour to save hour and minutes to time-crime-will-happen field  in behaviour folder
- added css script to align the two text box on same line.
- created 2 static json file to to render the hours and minutes in data/hour.json and data/minutes.json
- added properties(label etc) to hour and minutes in field.json and fields/index.js file 
- added a new view for time-crime-will-happen in the view section.
## Testing?
Tested manually and works fine.
## Screenshots (optional)
## Anything Else? (optional)
