### PR TITLE
PAF-196 validation for date, only accept future date

### DIFF
--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -1,5 +1,6 @@
 
 'use strict';
+
 const nationalities = require('../data/nationalities');
 const _ = require('lodash');
 const countriesList = require('../data/countriesList');
@@ -8,6 +9,7 @@ const airlineCompanies = require('../data/airlineCompanies');
 const occupation = require('../data/occupation');
 const companyTypes = require('../data/companyTypes');
 const dateComponent = require('hof').components.date;
+
 function notBothOptions(vals) {
   const values = _.castArray(vals);
   return !(values.length > 1 && values.indexOf('crime-transport-unknown') > -1);
@@ -18,7 +20,8 @@ function lettersAndSpacesOnly(value) {
 const moment = require('moment');
 const after1900Validator = { type: 'after', arguments: ['1900'] };
 const PRETTY_DATE_FORMAT = 'Do MMMM YYYY';
-
+const todayDate = new Date().toString();
+const afterCurrentYearValidator = { type: 'after', arguments: [todayDate] };
 module.exports = {
   'crime-type': {
     mixin: 'radio-group',
@@ -130,7 +133,8 @@ module.exports = {
     ]
   },
   'date-crime-will-happen': dateComponent('date-crime-will-happen', {
-    mixin: 'input-date'
+    mixin: 'input-date',
+    validate: [afterCurrentYearValidator]
   }),
   'time-crime-will-happen-hour': {
     mixin: 'input-text',

--- a/apps/paf/translations/src/en/validation.json
+++ b/apps/paf/translations/src/en/validation.json
@@ -21,7 +21,8 @@
     "maxlength": "You can't use more than {{maxlength}} characters for your answer"
   },
   "date-crime-will-happen": {
-    "date": "Please enter a valid date"
+    "date": "Please enter a valid date",
+    "after": "You must give a date in the future"
   },
   "when-crime-will-happen-more-info": {
     "maxlength": "You must enter no more than 1200 characters"

--- a/apps/paf/views/date-time-crime-will-happen.html
+++ b/apps/paf/views/date-time-crime-will-happen.html
@@ -14,9 +14,11 @@
         </div>
       </fieldset>
     </div>
+    
     <div>
       <legend><strong>Date</strong></legend>
-      {{#input-date}}date-crime-will-happen{{/input-date}}
+      
+      {{#renderField}}date-crime-will-happen{{/renderField}}
     </div>
     
     {{#input-submit}}continue{{/input-submit}}


### PR DESCRIPTION
## What?
[PAF-196](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-196) -Time (hh,mm)drop downs are missing from date-time-crime-will-happen page

## Why?
no bug found for the hour and minutes selected but, Error message not display for date when past date selected
## How?
- add error message in validation.json file
- capture the current year then implement the logic on the date textbox in Fields/index.js file

## Testing?
test locally and works fine 
## Screenshots (optional)
## Anything Else? (optional)
