### PR TITLE
PAF-200- Remove add additional button once the limit is reached

### DIFF
--- a/apps/paf/views/add-another.html
+++ b/apps/paf/views/add-another.html
@@ -2,7 +2,7 @@
    {{$page-content}}
      {{> partials-items-table}}
      {{#noMorePersons}}
-     <p><a role="link" class="govuk-link" aria-disabled="true">Add another {{addAnotherLinkText}}</a></p>
+     <p><a role="link" class="govuk-link add-another-hidden" >Add another {{addAnotherLinkText}}</a></p>
      {{/noMorePersons}}
      {{^noMorePersons}}
      <p><a href="{{baseUrl}}/{{addStep}}" class="govuk-link add-another">Add another {{addAnotherLinkText}}</a></p>

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -246,3 +246,6 @@ display: block;
 .time-input__item .govuk-error-message {
   display: none;
 }
+.add-another-hidden{
+  visibility: hidden;
+}


### PR DESCRIPTION
## What?
[PAF-200](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-200)- Additional people - 'Add another person' text still visible after 6 people have been added
## Why?
reported as bug
## How?
- add css script to hide the link once the limit is complete in app.scss file
- applied the css script to the link as a class property in add-another.html file 
## Testing?
Tested locally and works fine 
## Screenshots (optional)
![Screenshot 2024-01-23 at 09 06 43](https://github.com/UKHomeOffice/paf/assets/138882912/b4d8f21c-3aa8-4a44-8a0f-0dd9b58dfa2b)

## Anything Else? (optional)
