### PR TITLE
Fix weekly branch environment teardown and PR merge branch teardown

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -270,7 +270,7 @@ steps:
       - name: dockersock
         path: /root/.dockersock
     commands:
-      - drone build info $GIT_REPO $DRONE_BUILD_NUMBER --format {{.Message}} | grep -o '[^ ]\+$' -m1 | sed 's|UKHomeOffice/||g' | tr '[:upper:]' '[:lower:]' | tr '/' '-' > /root/.dockersock/branch_name.txt
+      - drone build info $GIT_REPO $DRONE_BUILD_NUMBER --format {{.Message}} | grep -o " '.*' " | tr -d "[ ']" | tr '[:upper:]' '[:lower:]' | tr '/' '-' > /root/.dockersock/branch_name.txt
     when:
       branch: master
       event: push
@@ -289,7 +289,7 @@ steps:
       - name: dockersock
         path: /root/.dockersock
     commands:
-      - sh bin/deploy.sh tear_down
+      - bin/deploy.sh tear_down
     when:
       branch: master
       event: push

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -14,7 +14,7 @@ if [[ $1 == 'tear_down' ]]; then
   export KUBE_NAMESPACE=$BRANCH_ENV
   export DRONE_SOURCE_BRANCH=$(cat /root/.dockersock/branch_name.txt)
   $kd --delete -f kube/configmaps/configmap.yml
-  $kd --delete -f kube/redis -f kube/app -f kube/ims-resolver
+  $kd --delete -f kube/redis -f kube/app -f kube/ims-resolver -f kube/file-vault
   # echo "Torn Down UAT Branch - paf-$DRONE_SOURCE_BRANCH.internal.$BRANCH_ENV.homeoffice.gov.uk"
   echo "Torn Down Branch - paf-${DRONE_SOURCE_BRANCH}.internal.${BRANCH_ENV}.homeoffice.gov.uk"
   exit 0


### PR DESCRIPTION
## What?

Updated config to tear down PR envs

## Why?

The drone/cron jobs that should tear down branch environment deployments when a) the accompanying PR is merged to master or b) weekly at the end of the week is currently not succeeding.

This appears to be because of older config not correctly calling the branches or cron jobs.

## How?

* Updated `deploy.sh` section to include all microservices deployed by PAF in the relevant delete command
* Updated drone pipeline steps to find PR branches and run commands to tear down

Copied new config/alterations from IMA and ASC projects where the jobs appear to work ok.

## Anything Else?

The drone cron job in the PAF project (drone/paf/settings/cron is currently misnamed as `tear_down_envs` and so it doesn't run any specific step from the `drone.yml`. After these changes we need to create a new cron job called `tear_down_pr_envs` with (ideally) the schedule `0 0 21 * * 5` (but stock 'weekly' would be ok)
