### PR TITLE
Paf 210 work for british government

### DIFF
--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -1346,7 +1346,7 @@ module.exports = {
       'male',
       'female',
       'other',
-      'gender-unknown'
+      'prefer-not-to-say'
     ]
   },
   'about-you-contact': {

--- a/apps/paf/index.js
+++ b/apps/paf/index.js
@@ -389,7 +389,7 @@ module.exports = {
         target: '/report-person-occupation-government-employee',
         condition: {
           field: 'report-person-occupation-type',
-          value: 'government-employee'
+          value: 'job-government-employee'
         }
       },
       {

--- a/apps/paf/translations/src/en/fields.json
+++ b/apps/paf/translations/src/en/fields.json
@@ -1333,8 +1333,8 @@
       "other": {
         "label": "Other"
       },
-      "gender-unknown": {
-        "label": "I don't know"
+      "prefer-not-to-say": {
+        "label": "Prefer not to say"
       }
     }
   },

--- a/lib/ims-hof-values-map.json
+++ b/lib/ims-hof-values-map.json
@@ -305,6 +305,10 @@
              "IMS": "DontKnow"
             },
             {
+            "HOF": "prefer-not-to-say",
+            "IMS": "DontKnow"
+            },
+            {
              "HOF": "uk",
              "IMS": "IntheUK"
             },


### PR DESCRIPTION
## What?
[PAF-210](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-210) 
- Does the person work for British government - Is missing from the UAT environment

## Why?
What type of job or occupation does the person have? Select Government Employee Next page Does the person work for the British government? is missing
## How?
- In report-person-occupation-type  and in the condition the value is changed to job-government-employee'

## Testing?
test locally and works fine 
