### PR TITLE
PAF-216 Add IMS mapping for crime-delivery page text boxes

### DIFF
--- a/lib/ims-hof-fields-map.json
+++ b/lib/ims-hof-fields-map.json
@@ -245,6 +245,18 @@
         "HOF": "crime-delivery"
         },
         {
+        "IMS": "txPostOther",
+        "HOF": "freight-more-info"
+        },
+        {
+        "IMS": "txPostOther",
+        "HOF": "express-more-info"
+        },
+        {
+        "IMS": "txPostOther",
+        "HOF": "post-more-info"
+        },
+        {
         "IMS": "rdwherecrime",
         "HOF": "crime-location"
         },


### PR DESCRIPTION
## What?

Added IMS mapping for the three 'more info' text boxes that conditionally display on the crime-delivery page when certain radio options are selected.

## Why?

It was observed that data entered into these boxes would not show up in a submitted case on IMS. This was because the mapping between these fields and IMS was not established

## How?

Added new field mappings for the three text boxes to `lib/ims-hof-fields-map.json`

## Testing?

Tested from local and observed correct data entered into the field in IMS cases for each of the three options that provides an opportunity to give more information.

Further testing to be done on branch, UAT

## Anything Else?

The three new fields from the HOF form map into the same IMS field. It was observed that if a user had entered info into all three fields the webform will only submit the info related to the option that was selected by radio button. Where a field was empty it would not overwrite existing data as empty into the IMS submission because empty fields are then ignored.
