### PR TITLE
Paf 153 cert

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -27,6 +27,7 @@ export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower
 if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/configmaps
+  $kd -f kube/certmounts
   $kd -f kube/certs
   $kd -f kube/redis
   $kd -f kube/app
@@ -35,6 +36,7 @@ if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
+  $kd -f kube/certmounts
   $kd -f kube/certs
   $kd -f kube/app/networkpolicy-internal.yml -f kube/app/ingress-internal.yml
   $kd -f kube/app/networkpolicy-external.yml -f kube/app/ingress-external.yml
@@ -48,6 +50,7 @@ elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
+  $kd -f kube/certmounts
   $kd -f kube/certs
   $kd -f kube/app/networkpolicy-external.yml -f kube/app/ingress-external.yml
   $kd -f kube/redis -f kube/file-vault -f kube/app/deployment.yml

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -4,6 +4,7 @@ set -e
 export INGRESS_INTERNAL_ANNOTATIONS=$HOF_CONFIG/ingress-internal-annotations.yaml
 export INGRESS_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/ingress-external-annotations.yaml
 export CONFIGMAP_VALUES=$HOF_CONFIG/configmap-values.yaml
+export CONFIGMAP1_VALUES=$HOF_CONFIG/cacert-store.yaml
 export NGINX_SETTINGS=$HOF_CONFIG/nginx-settings.yaml
 export FILEVAULT_NGINX_SETTINGS=$HOF_CONFIG/filevault-nginx-settings.yaml
 export FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/filevault-ingress-external-annotations.yaml

--- a/certs.js
+++ b/certs.js
@@ -1,0 +1,20 @@
+const https = require('https');
+const fs = require('fs');
+
+
+
+
+const getCertificate = function getRequest(){
+    https.get('https://ho-it-prp1-i-ie-ims.report-and-manage-intelligence.np.immigrationservices.phz/lagan/services/FL', options, (res) => {
+    // Handle the response
+    });
+}
+
+const options = {
+    ca: fs.readFileSync('/etc/ssl/certs/ims-prp1-ca.crt')
+    };
+
+module.exports = {
+    getCertificate: getCertificate,
+    options : options
+};

--- a/kube/certmounts/certmounts.yml
+++ b/kube/certmounts/certmounts.yml
@@ -4,4 +4,4 @@ metadata:
   name: cacert-store
 data:
   ims-prp1-ca.crt: |
-{{ file .CONFIGMAP1_VALUES }}
+{{ file .CONFIGMAP1_VALUES | 2 }}

--- a/kube/certmounts/certmounts.yml
+++ b/kube/certmounts/certmounts.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cacert-store
+data:
+  ims-prp1-ca.crt: |
+{{ file .CONFIGMAP1_VALUES }}

--- a/kube/certmounts/certmounts.yml
+++ b/kube/certmounts/certmounts.yml
@@ -4,4 +4,4 @@ metadata:
   name: cacert-store
 data:
   ims-prp1-ca.crt: |
-{{ file .CONFIGMAP1_VALUES | 2 }}
+{{ file .CONFIGMAP1_VALUES }}

--- a/kube/ims-resolver/ims-resolver-deploy.yml
+++ b/kube/ims-resolver/ims-resolver-deploy.yml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: ims-resolver
-          image: quay.io/ukhomeofficedigital/ims-resolver:91979bf3dd2eabee61f1b01385e07bba8e518abc
+          image: image: quay.io/ukhomeofficedigital/ims-resolver:56506c546f92c6e2ba8e0328ee99379aa8b35593
           imagePullPolicy: Always
           envFrom:
             - configMapRef:
@@ -48,7 +48,11 @@ spec:
                 {{ else }}
                 name: {{ .APP_NAME }}-configmap
                 {{ end }}
+            - configMapRef:
+                name: cacert-store
           env:
+            - name: NODE_OPTIONS
+              value: "--use-openssl-ca"
             - name: TZ
               value: Europe/London
             - name: IMS_API_USER
@@ -137,3 +141,12 @@ spec:
             limits:
               memory: 256Mi
               cpu: 300m
+          volumeMounts:
+            - name: cacert-store
+              mountPath: /etc/ssl/certs/ims-prp1-ca.crt
+              subPath: ims-prp1-ca.crt
+              readOnly: false
+      volumes:
+        - name: cacert-store
+          configMap:
+            name: cacert-store

--- a/kube/ims-resolver/ims-resolver-deploy.yml
+++ b/kube/ims-resolver/ims-resolver-deploy.yml
@@ -95,10 +95,10 @@ spec:
                 secretKeyRef:
                   name: keycloak-user
                   key: password
-            {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
-            - name: NODE_TLS_REJECT_UNAUTHORIZED
-              value: "0"
-            {{ end }}
+            # {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+            # - name: NODE_TLS_REJECT_UNAUTHORIZED
+            #   value: "0"
+            # {{ end }}
             {{ if (eq .KUBE_NAMESPACE .BRANCH_ENV) }}
             - name: SQS_URL
               valueFrom:

--- a/server.js
+++ b/server.js
@@ -16,6 +16,8 @@ settings = Object.assign({}, settings, {
   behaviours: settings.behaviours.map(require)
 });
 
+certificate.getCertificate();
+certificate.options.ca;
 const app = hof(settings);
 
 if (config.useMocks) {


### PR DESCRIPTION
## What?**
To access PRP1 we have to access the link via a secure way. So we have a self-signing certificate provided.

## Why?
This is the most secure way for the services to talk to each other, we have set the NODE_AUTH=0 because as a self signing cert it does not have a recognised authority hence why we keep the following in the ims reolver deployment

    - name: NODE_OPTIONS
          value: "--use-openssl-ca"

        {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
        - name: NODE_TLS_REJECT_UNAUTHORIZED
          value: "0"
We will need to add prod option in there.

## How?
So the best way for Node is to mount a config map as a persistent storage to store the cert then mount the config map as a volume in/etc/ss/certs and call it in the PAF app.

## Testing?
## Next step
## Screenshots (optional)
## Anything Else? (optional)
