### PR TITLE
PAF-214 Allow users to enter further details when the reported person's job is 'Other'

### DIFF
--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -868,7 +868,8 @@ module.exports = {
     }
   },
   'report-person-occupation-other': {
-    labelClassName: 'visuallyhidden'
+    labelClassName: 'visuallyhidden',
+    validate: [{ type: 'maxlength', arguments: 50 }]
   },
   'report-person-occupation-hours': {
     mixin: 'input-text',

--- a/apps/paf/index.js
+++ b/apps/paf/index.js
@@ -403,7 +403,7 @@ module.exports = {
         target: '/report-person-occupation-other',
         condition: {
           field: 'report-person-occupation-type',
-          value: 'other'
+          value: 'job-other'
         }
       }
       ]


### PR DESCRIPTION
## What?

Updated the conditional value upon which a user is shown a page to give further details on the reported person's job if it was  'Other' from the main list

## Why?

The conditional value on `'report-person-occupation-type'` was incorrect and so users would not be shown the `/report-person-occupation-other` page. Without this the corresponding field in IMS cases will always be empty.

## Testing?

Tested locally and observed the `/report-person-occupation-other` appears when a user selects 'Other' in the `'report-person-occupation-type'` field on the previous page.

Observed that detail entered in the `/report-person-occupation-other` appeared in the corresponding field in a new case on PRP1 IMS.
