### PR TITLE
PAF-207-missing-questions-answers

### DIFF
--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -807,6 +807,12 @@ module.exports = {
         label: 'fields.report-person-location-travel-to-uk-country.options.null'
       }].concat(countriesList)
   },
+  'report-person-location-travel-to-uk-how': {
+    mixin: 'input-text'
+  },
+  'report-person-location-travel-to-uk-where': {
+    mixin: 'input-text'
+  },
   'report-person-location-type': {
     isPageHeading: true,
     mixin: 'radio-group',

--- a/apps/paf/sections/summary-data-sections.js
+++ b/apps/paf/sections/summary-data-sections.js
@@ -152,7 +152,9 @@ module.exports = {
     {
       field: 'report-person-location-travel-to-uk-country',
       parse: v => _.get(_.find(COUNTRIES, group => group.value === v), 'label', '')
-    }
+    },
+    'report-person-location-travel-to-uk-how',
+    'report-person-location-travel-to-uk-where'
   ],
   'person-occupation': [
     'report-person-occupation',

--- a/test/_unit/sections/summary-data-sections.spec.js
+++ b/test/_unit/sections/summary-data-sections.spec.js
@@ -186,7 +186,9 @@ describe('PAF Summary Data Sections', () => {
         'report-person-location-mobile',
         'report-person-location-phone',
         'report-person-location-email',
-        'report-person-location-travel-to-uk-country'
+        'report-person-location-travel-to-uk-country',
+        'report-person-location-travel-to-uk-how',
+        'report-person-location-travel-to-uk-where'
       ];
       const result = areOrderedEqual(sectionFields, expectedFields);
       expect(result).to.be.true;


### PR DESCRIPTION
## What?

PAF-207 Missing questions and answers on 'Check Your Answers' Page



## Why?

In 'Check Your Answers' Page  questions and answers are missing

## How?
Additional fields 
        'report-person-location-travel-to-uk-how',
        'report-person-location-travel-to-uk-where'   are added  in summary-data-sections.js in person-contact
Tests are amended with new fields.

## Testing

Tested locally 
