### PR TITLE
Weekly teardown fix: Remove ls command from start of kd container

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -362,8 +362,7 @@ steps:
       KUBE_TOKEN:
         from_secret: kube_token_dev
     commands:
-      - ls -al bin
-      - sh bin/clean_up.sh $${BRANCH_ENV}
+      - bin/clean_up.sh $${BRANCH_ENV}
     when:
       cron: tear_down_pr_envs
       event: cron

--- a/.drone.yml
+++ b/.drone.yml
@@ -362,7 +362,7 @@ steps:
       KUBE_TOKEN:
         from_secret: kube_token_dev
     commands:
-      - bin/clean_up.sh $${BRANCH_ENV}
+      - sh bin/clean_up.sh $${BRANCH_ENV}
     when:
       cron: tear_down_pr_envs
       event: cron


### PR DESCRIPTION
## What?

Remove ls command when starting kd container for weekly branch env teardown job

## Why?

The command as the entrypoint to the job is possibly stopping the container from being up long enough to run the following teardown script. Removing this will make the script the entrypoint command of the container

## How?

Updated `drone.yml` file to change the pipeline step.

## Testing?

To be done overnight on the cron job.
