### PR TITLE
HOFF-613: Replace Anchore with Trivy

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -141,6 +141,26 @@ steps:
           - feature/*
       event: [push, pull_request]
 
+  # Trivy Security Scannner
+  - name: scan-image
+    pull: always
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
+    resources:
+      limits:
+        cpu: 1000
+        memory: 1024Mi
+    environment:
+      IMAGE_NAME: paf:${DRONE_COMMIT_SHA}
+      SEVERITY: MEDIUM,HIGH,CRITICAL
+      FAIL_ON_DETECTION: false
+      IGNORE_UNFIXED: true
+      ALLOW_CVE_LIST_FILE: hof-services-config/Public_Allegation_Form/trivy-cve-exceptions.txt
+    when:
+      event:
+      - pull_request
+      - push
+      - tag
+
   # Deploy to pull request UAT environment.
   - name: deploy_to_branch
     pull: if-not-exists
@@ -210,7 +230,7 @@ steps:
           - feature/*
       event: pull_request
 
-  # Snyk & Anchore security scans which run after branch deployment to prevent blocking of PR UAT tests.
+  # Snyk  security scans which run after branch deployment to prevent blocking of PR UAT tests.
   - name: snyk_scan
     pull: if-not-exists
     image: node:18
@@ -353,7 +373,7 @@ steps:
       cron: tear_down_pr_envs
       event: cron
 
-  # CRON job steps that runs security scans using Snyk & Anchore
+  # CRON job steps that runs security scans using Snyk & Trivy
   - name: cron_clone_repos
     image: alpine/git
     environment:
@@ -392,14 +412,15 @@ steps:
       cron: security_scans
       event: cron
 
-  - name: cron_anchore_scan
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
+  - name: cron_trivy_scan
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
     pull: always
     environment:
       IMAGE_NAME: paf:${DRONE_COMMIT_SHA}
-      LOCAL_IMAGE: true
-      TOLERATE: medium
-      WHITELIST_FILE: hof-services-config/Appeal_Rights_Exhausted/anchore-cve-exceptions.txt
+      SEVERITY: MEDIUM,HIGH,CRITICAL
+      FAIL_ON_DETECTION: false
+      IGNORE_UNFIXED: true
+      ALLOW_CVE_LIST_FILE: hof-services-config/Public_Allegation_Form/trivy-cve-exceptions.txt
     when:
       cron: security_scans
       event: cron
@@ -429,7 +450,7 @@ steps:
       failure: ignore
       icon_url: http://readme.drone.io/0.5/logo_dark.svg
       icon.url: http://readme.drone.io/0.5/logo_dark.svg
-      template: "CRON Job {{build.deployTo}} of Appeal Rights Exhausted has {{build.status}} - <{{build.link}}|#{{build.number}}> {{#success build.status}}\n :thumbsup: :thumbsup: :thumbsup:\n{{else}}\n :x: :x: :x:\n{{/success}} Author: {{build.author}}\n\nDuration: {{since job.started}}\n\nJob: <{{build.link}}|#{{build.number}}>\n\nCommit: {{build.commit}}\n"
+      template: "CRON Job {{build.deployTo}} of Public Allegation Form has {{build.status}} - <{{build.link}}|#{{build.number}}> {{#success build.status}}\n :thumbsup: :thumbsup: :thumbsup:\n{{else}}\n :x: :x: :x:\n{{/success}} Author: {{build.author}}\n\nDuration: {{since job.started}}\n\nJob: <{{build.link}}|#{{build.number}}>\n\nCommit: {{build.commit}}\n"
       username: Drone
       webhook:
         from_secret: slack_webhook
@@ -441,13 +462,6 @@ steps:
 services:
   - name: docker
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
-
-  # Anchore scanning needs background service to run
-  - name: anchore-submission-server
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
-    pull: always
-    commands:
-      - /run.sh server
 
   # Redis session setup in background so integration tests can run
   - name: session


### PR DESCRIPTION
What?
I've added Trivy Scanner to Pipeline and removed deprecated Anchore Scanner for the PAF service, see ticket
[https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-613](url)

Why?
Trivy will let you scan images, file systems and repositories for any vulnerabilities and issues. It will detect CVEs of OS packages, applications susceptibilities, and exposures of IaC in Terraform files, Kubernetes and Docker.
Drawback of Anchore Scanner is it’s significantly slower, the process of using it is more cumbersome, the output is less friendly and most importantly, it scans fewer CVEs.
See [https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-613](url) for more information.

How?
Removed Anchore cve exception file and added trivy cve exception file in hof-services-config repo from PAF service configs.
Removed Anchore Scanner steps from pipeline and added trivy scanner steps with cron scanner.
Our Acceptance criteria is to list the Medium to Critical vulnerabilities.

Testing?
We can test it by raising pull request to Master branch. Drone Pipeline should run through the steps and should list the Medium to Critical Vulnerabilties and should progress to next steps of deployment to branch
[https://drone-gh.acp.homeoffice.gov.uk/UKHomeOffice/paf/984](url)
[https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-613](url)

Screenshots
This screenshot is from Drone CI console
<img width="1016" alt="image" src="https://github.com/UKHomeOffice/paf/assets/146218064/ec3f9dc2-0d0f-4e6f-a021-abfe7a6d1785">
