### PR TITLE
PAF-225 Replace generic unknown with field specific values

### DIFF
--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -168,7 +168,7 @@ module.exports = {
       child: 'checkbox-group'
     },
     'no',
-    'unknown']
+    'transport-unknown']
   },
   'transport-group': {
     mixin: 'checkbox-group',
@@ -501,7 +501,7 @@ module.exports = {
         child: 'textarea'
       },
       'none',
-      'unknown'
+      'delivery-unknown'
     ]
   },
   'freight-more-info': {
@@ -856,7 +856,7 @@ module.exports = {
   'report-person-occupation': {
     mixin: 'radio-group',
     isPageHeading: true,
-    options: ['yes', 'no', 'unknown']
+    options: ['yes', 'no', 'occupation-unknown']
   },
   'report-person-occupation-type': {
     mixin: 'select',
@@ -870,7 +870,7 @@ module.exports = {
   'report-person-occupation-government-employee': {
     mixin: 'radio-group',
     isPageHeading: true,
-    options: ['yes', 'no', 'unknown']
+    options: ['yes', 'no', 'govt-employ-unknown']
   },
   'report-person-occupation-government-dept': {
     mixin: 'radio-group',
@@ -908,7 +908,7 @@ module.exports = {
   'report-person-occupation-where': {
     isPageHeading: true,
     mixin: 'radio-group',
-    options: ['yes', 'no', 'unknown']
+    options: ['yes', 'no', 'occupation-where-unknown']
   },
   'report-person-occupation-company-name': {
     mixin: 'input-text',
@@ -941,12 +941,12 @@ module.exports = {
   },
   'report-person-occupation-company-manager-know': {
     mixin: 'radio-group',
-    options: ['yes', 'no', 'unknown']
+    options: ['yes', 'no', 'occ-manager-know-unknown']
   },
   'report-person-study': {
     mixin: 'radio-group',
     isPageHeading: true,
-    options: ['yes', 'no', 'unknown']
+    options: ['yes', 'no', 'study-unknown']
   },
   'report-person-study-subject': {
     mixin: 'input-text',
@@ -955,12 +955,12 @@ module.exports = {
   'report-person-study-location': {
     isPageHeading: true,
     mixin: 'radio-group',
-    options: ['yes', 'no', 'unknown']
+    options: ['yes', 'no', 'study-location-unknown']
   },
   'report-person-study-where': {
     isPageHeading: true,
     mixin: 'radio-group',
-    options: ['yes', 'no', 'unknown']
+    options: ['yes', 'no', 'study-where-unknown']
   },
   'report-person-study-hours': {
     mixin: 'input-text',
@@ -1009,12 +1009,12 @@ module.exports = {
   },
   'report-person-study-manager-know': {
     mixin: 'radio-group',
-    options: ['yes', 'no', 'unknown']
+    options: ['yes', 'no', 'study-manager-know-unknown']
   },
   'report-person-transport': {
     isPageHeading: true,
     mixin: 'radio-group',
-    options: ['yes', 'no', 'unknown']
+    options: ['yes', 'no', 'transport-unknown']
   },
   'report-transport-group': {
     legend: {
@@ -1225,7 +1225,7 @@ module.exports = {
   },
   'report-organisation': {
     mixin: 'radio-group',
-    options: ['yes', 'no', 'unknown']
+    options: ['yes', 'no', 'report-org-unknown']
   },
   'organisation-company-name': {
     isPageHeading: true,
@@ -1279,7 +1279,7 @@ module.exports = {
     options: [
       'yes',
       'no',
-      'unknown'
+      'org-owner-know-unknown'
     ]
   },
   'company-other-info': {

--- a/apps/paf/translations/src/en/fields.json
+++ b/apps/paf/translations/src/en/fields.json
@@ -143,7 +143,7 @@
       "no": {
         "label": "No"
       },
-      "unknown": {
+      "transport-unknown": {
         "label": "I don't know"
       }
     }
@@ -464,7 +464,7 @@
       "none": {
         "label": "None of these"
       },
-      "unknown": {
+      "delivery-unknown": {
         "label": "I don't know"
       }
     }
@@ -765,7 +765,7 @@
       "no": {
         "label": "No"
       },
-      "unknown": {
+      "occupation-unknown": {
         "label": "I don't know"
       }
     }
@@ -785,7 +785,7 @@
       "no": {
         "label": "No"
       },
-      "unknown": {
+      "govt-employ-unknown": {
         "label": "I don't know"
       }
     }
@@ -828,7 +828,7 @@
       "no": {
         "label": "No"
       },
-      "unknown": {
+      "occupation-where-unknown": {
         "label": "I don't know"
       }
     }
@@ -866,7 +866,7 @@
       "no": {
         "label": "No"
       },
-      "unknown": {
+      "occ-manager-know-unknown": {
         "label": "I don't know"
       }
     }
@@ -880,7 +880,7 @@
       "no": {
         "label": "No"
       },
-      "unknown": {
+      "study-unknown": {
         "label": "I don't know"
       }
     }
@@ -897,7 +897,7 @@
       "no": {
         "label": "No"
       },
-      "unknown": {
+      "study-location-unknown": {
         "label": "I don't know"
       }
     }
@@ -917,7 +917,7 @@
       "no": {
         "label": "No"
       },
-      "unknown": {
+      "study-where-unknown": {
         "label": "I don't know"
       }
     }
@@ -961,7 +961,7 @@
       "no": {
         "label": "No"
       },
-      "unknown": {
+      "study-manager-know-unknown": {
         "label": "I don't know"
       }
     }
@@ -975,7 +975,7 @@
       "no": {
         "label": "No"
       },
-      "unknown": {
+      "transport-unknown": {
         "label": "I don't know"
       }
     }
@@ -1220,7 +1220,7 @@
       "no": {
         "label": "No"
       },
-      "unknown": {
+      "report-org-unknown": {
         "label": "I don't know"
       }
     }
@@ -1271,7 +1271,7 @@
       "no": {
         "label": "No"
       },
-      "unknown": {
+      "org-owner-know-unknown": {
         "label": "I don't know"
       }
     }

--- a/lib/ims-hof-values-map.json
+++ b/lib/ims-hof-values-map.json
@@ -75,8 +75,8 @@
         { "HOF": "male", "IMS": "Male" },
         { "HOF": "female", "IMS": "Female" },
         { "HOF": "other", "IMS": "Other" },
-        { "HOF": "gender-unknown", "IMS": "DontKnow" },
-        { "HOF": "prefer-not-to-say", "IMS": "DontKnow" },
+        { "HOF": "gender-unknown", "IMS": "Idontknow" },
+        { "HOF": "prefer-not-to-say", "IMS": "Prefer not to say" },
         { "HOF": "uk", "IMS": "IntheUK" },
         { "HOF": "outside-uk", "IMS": "OutsidetheUK" },
         { "HOF": "travel-to-uk", "IMS": "TravellingtotheUK" },
@@ -709,6 +709,19 @@
         { "HOF": "Zaire", "IMS": "CountryList.ZAR" },
         { "HOF": "Zambia", "IMS": "CountryList.ZMB" },
         { "HOF": "Zimbabwe", "IMS": "CountryList.ZWE" },
-        { "HOF": "Unknown", "IMS": "CountryList.UKN" }
+        { "HOF": "Unknown", "IMS": "CountryList.UKN" },
+        { "HOF": "transport-unknown", "IMS": "Idontknow" },
+        { "HOF": "delivery-unknown", "IMS": "I dont know" },
+        { "HOF": "occupation-unknown", "IMS": "Idontknow" },
+        { "HOF": "govt-employ-unknown", "IMS": "DontKnow" },
+        { "HOF": "occupation-where-unknown", "IMS": "Idontknow" },
+        { "HOF": "occ-manager-know-unknown", "IMS": "DontKnow" },
+        { "HOF": "study-unknown", "IMS": "Idontknow" },
+        { "HOF": "study-location-unknown", "IMS": "Idontknow" },
+        { "HOF": "study-where-unknown", "IMS": "Idontknow" },
+        { "HOF": "study-manager-know-unknown", "IMS": "DontKnow" },
+        { "HOF": "transport-unknown", "IMS": "Idontknow" },
+        { "HOF": "report-org-unknown", "IMS": "Idontknow" },
+        { "HOF": "org-owner-know-unknown", "IMS": "dontknow" }
     ]
 }

--- a/test/helpers/add-allegation-data/data_with_addition_person.js
+++ b/test/helpers/add-allegation-data/data_with_addition_person.js
@@ -63,9 +63,9 @@ module.exports = {
     + 'personAddNickname:test, personAddDob:1985-02-01, personAddAgeRange:35-44, '
     + 'personAddNationality:Nationality-India, personAddGender:male'
   ],
-  'crime-transport': 'unknown',
+  'crime-transport': 'transport-unknown',
   'transport-group': '',
-  'crime-delivery': 'unknown',
+  'crime-delivery': 'delivery-unknown',
   'freight-more-info': '',
   'express-more-info': '',
   'post-more-info': '',
@@ -77,7 +77,7 @@ module.exports = {
   'crime-location-address-county': '',
   'crime-location-address-postcode': '',
   'crime-location-phone': '',
-  'report-organisation': 'unknown',
+  'report-organisation': 'report-org-unknown',
   'other-info-description': '',
   'other-info-another-crime': 'no',
   'other-info-another-crime-description': '',
@@ -104,9 +104,9 @@ module.exports = {
   'report-person-id': '',
   'report-person-ni': '',
   'report-person-location': 'location-unknown',
-  'report-person-occupation': 'unknown',
-  'report-person-study': 'unknown',
-  'report-person-transport': 'unknown',
+  'report-person-occupation': 'occupation-unknown',
+  'report-person-study': 'study-unknown',
+  'report-person-transport': 'transport-unknown',
   'report-person-description': '',
   hasAdditionalPerson: 'yes',
   images: [


### PR DESCRIPTION
## What?

Updated several fields where the value was a generic 'unknown' to use more specific x-unknown format following the pattern of some values already in that format.

Corrected a couple of existing specific values that appeared to map incorrectly to IMS

## Why?

There are several different possible values in IMS for radios that have the option 'I don't know' (e.g. IDontKnow, DontKnow, Idontknow, I dont know). There appears to have been no pattern to the way these were assigned, but it means each field where an 'I don't know' answer is possible needs to be mapped individually to the specific IMS version for that field.

## Testing?

Tested locally and observed that for all found fields 'I don't know' values appear mapped correctly into IMS
