### PR TITLE
Teardown - try hardcode branch env name in drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -368,7 +368,7 @@ steps:
       KUBE_TOKEN:
         from_secret: kube_token_dev
     commands:
-      - sh bin/clean_up.sh $${BRANCH_ENV}
+      - sh bin/clean_up.sh sas-paf-branch
     when:
       cron: tear_down_pr_envs
       event: cron


### PR DESCRIPTION
## What?

Hardcode branch env name in `.drone.yml` to see if this affects the unsuccessful weekly teardown job.

## Why?

Something is stopping the KD container from starting and running the command altered here. It can be run manually from the drone debugger when sas-paf-branch is added as an argument to the script.

Hardcoding that as it would be run manually to see if this improves things.
