### PR TITLE
Bug fix : Gender question - 'I don't know' for additional people shows up as 'add-gender-unknown'

### DIFF
--- a/apps/paf/behaviours/additional-person-formatter.js
+++ b/apps/paf/behaviours/additional-person-formatter.js
@@ -1,5 +1,12 @@
 const _ = require('lodash');
 const fieldsMap = require('../../../lib/ims-hof-fields-map.json');
+const valuesMap = require('../../../lib/ims-hof-person-add-values.json');
+
+const transform = item => {
+  const value = _.find(valuesMap.Values, {HOF: item.value});
+  const imsValue = value === undefined ? item.value : value.IMS;
+  return {Key: _.find(fieldsMap.Fields, {HOF: item.field}).IMS, StringValue: imsValue};
+};
 
 module.exports = superclass => class  extends superclass {
   configure(req, res, next) {
@@ -10,9 +17,7 @@ module.exports = superclass => class  extends superclass {
       _.forEach(persons.aggregatedValues, i => {
         const person = new Array();
         i.fields.map(item => item.value !== '' ?
-          person.push({Key: _.find(fieldsMap.Fields, {HOF: item.field}).IMS,
-            StringValue: item.value}) : '');
-
+          person.push(transform(item)) : '');
         additionalPeople.push(person);
 
         req.sessionModel.set('persons', additionalPeople);

--- a/apps/paf/behaviours/aggregator.js
+++ b/apps/paf/behaviours/aggregator.js
@@ -193,7 +193,7 @@ module.exports = superclass => class extends superclass {
   parseField(field, value, req) {
     const fieldName = field.field || field;
     const parser = req.form.options.fieldsConfig[fieldName].parse;
-    return parser ? parser(value) : value;
+    return parser ? parser(value, fieldName, req) : value;
   }
 
   locals(req, res) {

--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -1240,10 +1240,11 @@ module.exports = {
   personAddGender: {
     mixin: 'radio-group',
     isPageHeading: true,
+    parse: (value, field, req) => req.translate(`fields[${field}].options.[${value}]`),
     options: [
-      'Male',
-      'Female',
-      'Other',
+      'male',
+      'female',
+      'other',
       'add-gender-unknown'
     ]
   },

--- a/apps/paf/translations/src/en/fields.json
+++ b/apps/paf/translations/src/en/fields.json
@@ -1187,13 +1187,13 @@
   "personAddGender": {
     "legend": "What is the person's gender?",
     "options": {
-      "Male": {
+      "male": {
         "label": "Male"
       },
-      "Female": {
+      "female": {
         "label": "Female"
       },
-      "Other": {
+      "other": {
         "label": "Other"
       },
       "add-gender-unknown": {

--- a/lib/ims-hof-person-add-values.json
+++ b/lib/ims-hof-person-add-values.json
@@ -1,0 +1,8 @@
+{
+    "Values": [
+        { "HOF": "male", "IMS": "Male" },
+        { "HOF": "female", "IMS": "Female" },
+        { "HOF": "other", "IMS": "Other" },
+        { "HOF": "add-gender-unknown", "IMS": "IDontKnow"}
+    ]
+}

--- a/lib/ims-hof-values-map.json
+++ b/lib/ims-hof-values-map.json
@@ -722,7 +722,6 @@
         { "HOF": "study-manager-know-unknown", "IMS": "DontKnow" },
         { "HOF": "transport-unknown", "IMS": "Idontknow" },
         { "HOF": "report-org-unknown", "IMS": "Idontknow" },
-        { "HOF": "org-owner-know-unknown", "IMS": "dontknow" },
-        { "HOF": "add-gender-unknown", "IMS": "IDontKnow"}
+        { "HOF": "org-owner-know-unknown", "IMS": "dontknow" }
     ]
 }


### PR DESCRIPTION
**What?**
Gender question - 'I don't know' for additional people shows up as 'add-gender-unknown'

**Why?**
There was no parse from value to label for additional people gender options
The mapping for gender options was incorrect

**How?**
Added a parse function for additional people gender options and created separate mapping for additional people

**Testing?**
Manual testing on local, branch and UAT forms and checking on Verint UI (PRP1)
