### PR TITLE
Corrected mapping for care home company type

### DIFF
--- a/lib/ims-hof-values-map.json
+++ b/lib/ims-hof-values-map.json
@@ -102,7 +102,7 @@
         { "HOF": "express-mail-courier", "IMS": "Express mail or courier" },
         { "HOF": "post", "IMS": "Post" },
         { "HOF": "company-building-construction", "IMS": "CompanyType.BuildingConstru" },
-        { "HOF": "company-care-home", "IMS": "CompanyType.CareAssistant" },
+        { "HOF": "company-care-home", "IMS": "CompanyType.CareHome" },
         { "HOF": "company-catering-and-hospitality", "IMS": "CompanyType.CateringandHospita" },
         { "HOF": "company-child-care-nursery", "IMS": "CompanyType.ChildcareNurser" },
         { "HOF": "company-cleaning", "IMS": "CompanyType.Cleaning" },


### PR DESCRIPTION
What?
The organisation company type dropdown value is not being set in IMS when Care home is selected in the dropdown

Why?
The mapping from hof to ims value for Care how was incorrect

How?
Corrected the mapping

Testing?
Manual testing on local, branch and UAT forms and checking on Verint UI (PRP1)