### PR TITLE
PAF-241: Public access to PAF UAT External url temporarily

### DIFF
--- a/kube/app/networkpolicy-external.yml
+++ b/kube/app/networkpolicy-external.yml
@@ -7,6 +7,10 @@ metadata:
   {{ else }}
   name: ingress-network-policy-external-{{ .APP_NAME }}
   {{ end }}
+  labels:
+    cert-manager.io/solver: route53
+  annotations:
+    cert-manager.io/enabled: "true"
 spec:
   podSelector:
     matchLabels:


### PR DESCRIPTION
## What?

* ITHC and Automation testers of EBSA require access
* Allow Public access to UAT ingress url for a duration (temporarily)
* Please refer to the ticket [https://collaboration.homeoffice.gov.uk/jira/browse/PAF-241](url)

## Why?

Currently the PAF UAT external url is restricted to POISE users only. ITHC and automated testers require access from EBSA, however EBSA is not willingly to share IP addresses to whitelist.

The hof team has decided to provide public access to https://paf.uat.sas-notprod.homeoffice.gov.uk/start for the duration of the ITHC and automated testing.

## How?
"cert-manager.io/enabled" will toggle cert-manager to handle to ingress resource. "cert-manager.io/solver: route53" label is added as the domain is whitelisted in namespaces hosted by AWS by Route53. 
please refer to ACP documentation for further information how these dns challenge works:https://docs.acp.homeoffice.gov.uk/how-to/security/cert-manager/#retrieve-a-certificate-for-a-service-behind-the-vpn 
Hof-services config labels for ingress-external-annotations are replaced by "cert-manager.io/solver: route53"

## Testing?
We need to check the public access of https://paf.uat.sas-notprod.homeoffice.gov.uk/start from our Dev Mac. Currently we are seeing 403 error

## Anything Else? (optional)
Following ETA as an example. Later upon instructions from team we will restrict back the access only to POISE.
