### PR TITLE
Removed redundant value and label Unknown from the Nationality list

### DIFF
--- a/apps/paf/data/nationalities.json
+++ b/apps/paf/data/nationalities.json
@@ -960,12 +960,8 @@
     "label": "Zimbabwe"
   },
   {
-    "value": "Nationality-unknown",
-    "label": "Unknown"
-  },
-  {
     "value": "Nationality-I Dont Know",
     "label": "I don't know"
   }
 ]
-  
+

--- a/lib/ims-hof-values-map.json
+++ b/lib/ims-hof-values-map.json
@@ -415,7 +415,6 @@
         { "HOF": "Nationality-Zaire", "IMS": "NatList.ZAR" },
         { "HOF": "Nationality-Zambia", "IMS": "NatList.ZMB" },
         { "HOF": "Nationality-Zimbabwe", "IMS": "NatList.ZWE" },
-        { "HOF": "Nationality-Unknown", "IMS": "NatList.UKN" },
         { "HOF": "Nationality-I Dont Know", "IMS": "NatList.DontKnow" },
         { "HOF": "Nationality-Saint Barthelemy", "IMS": "NatList.BLM" },
         { "HOF": "Nationality-Saint Helena, Ascension and Tristan da Cunha", "IMS": "NatList.SHN" },


### PR DESCRIPTION
## What?
Removed 'Unknown' from the Nationality List
## Why?
There are two similar options in the Nationality drop down - 'Unknown' and 'Nationality Currently Unknown', as there is no 'Unknown' in the current form, I have removed this
## Testing?
Tested form in local, branch and UAT
