### PR TITLE
Removed the 'I don't know' option for the question 'Do you wish to report an individual'

### DIFF
--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -691,7 +691,7 @@ module.exports = {
   },
   'report-person': {
     mixin: 'radio-group',
-    options: ['yes', 'no', 'unknown']
+    options: ['yes', 'no']
   },
   'report-person-first-name': {
     mixin: 'input-text',

--- a/apps/paf/translations/src/en/fields.json
+++ b/apps/paf/translations/src/en/fields.json
@@ -559,9 +559,6 @@
       },
       "no": {
         "label": "No"
-      },
-      "unknown": {
-        "label": "I don't know"
       }
     }
   },


### PR DESCRIPTION
## What?
Removed the 'I don't know' option for the question 'Do you wish to report an individual'
## Why?
There is no corresponding value in IMS 
## How?
Removed the 'I don't know' option from report-person
## Testing?
Test manually in local, branch and UAT
