### PR TITLE
Updated ims-resolver to not resolve error when there is ims failure

### DIFF
--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -1383,8 +1383,7 @@ module.exports = {
   'other-info-file-upload': {
     mixin: 'input-file',
     className: 'govuk-file-upload',
-    attributes: [],
-    validate: ['notUrl']
+    attributes: []
   },
   'add-other-info-file-upload': {
     isPageHeading: true,

--- a/kube/ims-resolver/ims-resolver-deploy.yml
+++ b/kube/ims-resolver/ims-resolver-deploy.yml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: ims-resolver
-          image: quay.io/ukhomeofficedigital/ims-resolver:e904ffbb9525ad98df74add7442dc1ebc9381aec
+          image: quay.io/ukhomeofficedigital/ims-resolver:60d9930fdd2d6a26e23981eceb8e721f76f30f0b
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
**What**
Removed resolve error when there is a failure while sending to ims so that allegation stays in the sqs and can be consumed again

**Why**
When the error is resolved the allegation is removed from SQS and is lost.

**How**
Removed resolve error from the code

**Test**
Tested locally by submitting an allegation with ops-nonlive turned off. An error was logged and the allegation was not sent. Connected to ops-nonlive and allegation was sent.
In branch and UAT this can be tested by submitting when PRP1 is turned off after hours and check next day if the allegation has been received in IMS
