### PR TITLE
WIP PAF-238 Add ga_4_tag mapping to branch deployment

### DIFF
--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -106,6 +106,11 @@ spec:
                 secretKeyRef:
                   name: sas-paf-branch-sqs-queue
                   key: secret_access_key
+            - name: GA_4_TAG    # Google Analytics v4 tracking code
+              valueFrom:
+                secretKeyRef:
+                  name: sas-paf-branch-analytics
+                  key: ga_4_tag
             {{ else if (eq .KUBE_NAMESPACE .UAT_ENV) }}
             - name: SQS_URL
               valueFrom:

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -106,7 +106,7 @@ spec:
                 secretKeyRef:
                   name: sas-paf-branch-sqs-queue
                   key: secret_access_key
-            - name: GA_4_TAG    # Google Analytics v4 tracking code
+            - name: GA_4_TAGXX    # Google Analytics v4 tracking code
               valueFrom:
                 secretKeyRef:
                   name: sas-paf-branch-analytics


### PR DESCRIPTION
## What?

[PAF-238 Implement Google Analytics for PAF](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-238)

Activate HOF's analytics by mapping the secret `ga_4_tag` into an envvar `GA_4_TAG`

## Why?

It is a standard requirement to collect usage data. Analytics collection is a built-in feature of HOF.

## How?

A Google issued identifier called a `tag` is sent to the Analytics backend on every page load. This is carried out via a small section of js code injected into the header of every page by HOF. This js gets the unique `tag` from an environment variable which was in turn populated from the secrets during deployment.

## Testing?

Inspection of the GA dashboard confirms data is collected.

