### PR TITLE
PAF 249 phone optional

### DIFF
--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -630,7 +630,7 @@ module.exports = {
   'crime-another-location-country': {
     mixin: 'select',
     className: ['typeahead', 'js-hidden'],
-    validate: ['required', 'notUrl'],
+    validate: ['notUrl'],
     options:
       [{
         value: '',

--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -1287,7 +1287,7 @@ module.exports = {
   },
   'company-phone': {
     className: ['govuk-input', 'govuk-input--width-20'],
-    validate: ['required', 'internationalPhoneNumber', { type: 'maxlength', arguments: 20 }]
+    validate: ['internationalPhoneNumber', { type: 'maxlength', arguments: 20 }]
   },
   'company-email': {
     formatter: ['removespaces'],

--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -794,7 +794,7 @@ module.exports = {
   'report-person-location-outside-uk-address-country': {
     mixin: 'select',
     className: ['typeahead', 'js-hidden'],
-    validate: ['required', 'notUrl'],
+    validate: ['notUrl'],
     options:
       [{
         value: '',

--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -1482,7 +1482,7 @@ module.exports = {
       field: 'are-you-eighteen',
       value: 'yes'
     },
-    validate: ['required', 'internationalPhoneNumber', { type: 'maxlength', arguments: 20 }]
+    validate: ['internationalPhoneNumber', { type: 'maxlength', arguments: 20 }]
   },
   'when-to-contact': {
     dependent: {

--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -825,7 +825,7 @@ module.exports = {
   'report-person-location-travel-to-uk-country': {
     mixin: 'select',
     className: ['typeahead', 'js-hidden'],
-    validate: ['required', 'notUrl'],
+    validate: ['notUrl'],
     options:
       [{
         value: '',

--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -683,7 +683,7 @@ module.exports = {
   },
   'crime-another-location-phone': {
     className: ['govuk-input', 'govuk-input--width-20'],
-    validate: ['required', 'internationalPhoneNumber', { type: 'maxlength', arguments: 20 }],
+    validate: ['internationalPhoneNumber', { type: 'maxlength', arguments: 20 }],
     dependent: {
       field: 'crime-another-location',
       value: 'yes'

--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -873,7 +873,7 @@ module.exports = {
   },
   'report-person-location-outside-uk-phone': {
     className: ['govuk-input', 'govuk-input--width-20'],
-    validate: ['required', { type: 'maxlength', arguments: 20 }]
+    validate: ['internationalPhoneNumber', { type: 'maxlength', arguments: 20 }]
   },
   'report-person-location-outside-uk-email': {
     validate: ['email', { type: 'maxlength', arguments: 100 }]

--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -610,7 +610,7 @@ module.exports = {
   },
   'crime-location-phone': {
     className: ['govuk-input', 'govuk-input--width-20'],
-    validate: ['notUrl', 'required', { type: 'maxlength', arguments: 20 }],
+    validate: ['internationalPhoneNumber', { type: 'maxlength', arguments: 20 }],
     dependent: {
       field: 'crime-location',
       value: 'yes'

--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -964,7 +964,7 @@ module.exports = {
   },
   'report-person-occupation-company-phone': {
     className: ['govuk-input', 'govuk-input--width-20'],
-    validate: ['required', 'internationalPhoneNumber', { type: 'maxlength', arguments: 20 }]
+    validate: ['internationalPhoneNumber', { type: 'maxlength', arguments: 20 }]
   },
   'report-person-occupation-company-manager': {
     mixin: 'input-text',
@@ -1028,7 +1028,7 @@ module.exports = {
   },
   'report-person-study-phone': {
     className: ['govuk-input', 'govuk-input--width-20'],
-    validate: ['required', 'internationalPhoneNumber', { type: 'maxlength', arguments: 20 }]
+    validate: ['internationalPhoneNumber', { type: 'maxlength', arguments: 20 }]
   },
   'report-person-study-email': {
     validate: ['notUrl', 'email', { type: 'maxlength', arguments: 100 }]

--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -557,7 +557,7 @@ module.exports = {
   'crime-location-country': {
     mixin: 'select',
     className: ['typeahead', 'js-hidden'],
-    validate: ['required', 'notUrl'],
+    validate: ['notUrl'],
     options:
       [{
         value: '',

--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -849,11 +849,11 @@ module.exports = {
   },
   'report-person-location-mobile': {
     className: ['govuk-input', 'govuk-input--width-20'],
-    validate: ['required', 'internationalPhoneNumber', { type: 'maxlength', arguments: 20 }]
+    validate: ['internationalPhoneNumber', { type: 'maxlength', arguments: 20 }]
   },
   'report-person-location-phone': {
     className: ['govuk-input', 'govuk-input--width-20'],
-    validate: ['required', 'internationalPhoneNumber', { type: 'maxlength', arguments: 20 }]
+    validate: ['internationalPhoneNumber', { type: 'maxlength', arguments: 20 }]
   },
   'report-person-location-email': {
     validate: ['email', { type: 'maxlength', arguments: 100 }]


### PR DESCRIPTION
## What?

[PAF-249 The Crime & The Organisation – Valid Phone number required](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-249)

```csv
route                                      ,field
/crime-location                            ,crime-location-phone
/crime-another-location                    ,crime-another-location-phone
/report-person-location-contact            ,report-person-location-mobile
/report-person-location-contact            ,report-person-location-phone
/company-contact                           ,company-phone
/crime-location                            ,crime-location-country
/report-person-location-outside-uk-address ,report-person-location-outside-uk-address-country
/report-person-location-outside-uk-address ,report-person-location-travel-to-uk-country
/report-person-location-travel-to-uk       ,report-person-location-travel-to-uk-country
/report-person-location-outside-uk-contact ,report-person-location-outside-uk-phone
/report-person-occupation-company-address  ,report-person-occupation-company-phone
/report-person-study-contact               ,report-person-study-phone
/are-you-eighteen                          ,contact-number
```


## Why?

Some input fields were set mandatory when they should be optional. 

## How?

By removing the 'required' flag from the validator

## Testing?

Manual page visits

## Screenshots (optional)
## Anything Else? (optional)
