### PR TITLE
PAF-253: Remove Certs from deploy scripts for PAF prod 

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -51,7 +51,6 @@ elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/certmounts
-  $kd -f kube/certs
   $kd -f kube/app/ingress-external.yml -f kube/app/networkpolicy-external.yml
   $kd -f kube/redis -f kube/file-vault
   $kd -f kube/app/deployment.yml


### PR DESCRIPTION
**What?**
We are seeing deployment issues in sas-paf-prod. Those secrets issued by certs aren't the actual onces being used by the deployments. I have looked at the Services ASC and IMA. They aren't deploying these certs to prod from deploy.sh script.
These work is part of resolving PAF prod  deployment issues
https://collaboration.homeoffice.gov.uk/jira/browse/PAF-253

**Why?**
We need to remove these misconfigured secrets which arent used by deployments.

**How?**
These secrets are already deployed using kubectl commands in paf prod by Shamil. After reviewing other hof services where these(secrets & Certs) are not part of deploy scripts , We have decided to deploy the secrets and certificates using kubectl commands.
These are the example/references that lead us to make this change,
ASC : https://github.com/UKHomeOffice/additional-security-checks/blob/master/bin/deploy.sh#L47
IMA: https://github.com/UKHomeOffice/ima/blob/master/bin/deploy.sh#L45
ETA: https://github.com/UKHomeOffice/eta/blob/master/bin/deploy.sh#L36

**Testing?
Screenshots (optional)
Anything Else? (optional)**