### PR TITLE
Paf 253: Resolve PAF deployment Issues

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ environment:
   STG_ENV: paf-stg
   UAT_ENV: sas-paf-uat
   BRANCH_ENV: sas-paf-branch
-  PRODUCTION_URL: imsallegations.homeoffice.gov.uk
+  PRODUCTION_URL: www.imsallegations.homeoffice.gov.uk
   IMAGE_URL: quay.io/ukhomeofficedigital
   IMAGE_REPO: paf
   GIT_REPO: UKHomeOffice/paf

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -50,7 +50,6 @@ elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml
   $kd -f kube/file-vault/file-vault-ingress.yml
-  $kd -f kube/certmounts
   $kd -f kube/app/ingress-external.yml -f kube/app/networkpolicy-external.yml
   $kd -f kube/redis -f kube/file-vault
   $kd -f kube/app/deployment.yml

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -51,7 +51,6 @@ elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/certmounts
-  $kd -f kube/certs
   $kd -f kube/app/ingress-external.yml -f kube/app/networkpolicy-external.yml
   $kd -f kube/redis -f kube/file-vault
   $kd -f kube/app/deployment.yml

--- a/kube/app/ingress-external.yml
+++ b/kube/app/ingress-external.yml
@@ -9,9 +9,7 @@ metadata:
   {{ end }}
 {{ file .INGRESS_EXTERNAL_ANNOTATIONS | indent 2 }}
 spec:
-  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
   ingressClassName: nginx-external
-  {{ end }}
   tls:
     - hosts:
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}

--- a/kube/file-vault/file-vault-ingress.yml
+++ b/kube/file-vault/file-vault-ingress.yml
@@ -9,7 +9,6 @@ metadata:
   {{ end }}
 {{ file .FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS | indent 2 }}
 spec:
-  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
   ingressClassName: nginx-external
   {{ end }}
   tls:

--- a/kube/file-vault/file-vault-ingress.yml
+++ b/kube/file-vault/file-vault-ingress.yml
@@ -10,7 +10,6 @@ metadata:
 {{ file .FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS | indent 2 }}
 spec:
   ingressClassName: nginx-external
-  {{ end }}
   tls:
     - hosts:
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}


### PR DESCRIPTION
## What?
Resolve PAF Prod Issues 
PAF prod URL 404 error
PAF acme pods created due to invalid certs issued by clusterissuer

## Why?
ACP documentation suggests us to use nginx external as Ingress class for external access of ingress
https://docs.acp.homeoffice.gov.uk/how-to/ingress/


## How?
removed conditional statements restricting nginx-external ingress class to non-prod env. Now All the external ingress are accessible outside VPN

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
