### PR TITLE
PAF-192: Fix Cron step failing in Drone 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -368,7 +368,7 @@ steps:
       KUBE_TOKEN:
         from_secret: kube_token_dev
     commands:
-      - sh bin/clean_up.sh sas-paf-branch
+      - bin/clean_up.sh $${BRANCH_ENV}
     when:
       cron: tear_down_pr_envs
       event: cron

--- a/bin/slack.sh
+++ b/bin/slack.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -e
+
+NAME=$(echo "${APP_NAME}" | tr '-' ' ' | tr '_' ' ' | tr '[:lower:]' '[:upper:]')
+HEADER="*${NAME} - ${PING_NAME}*"
+BUILD="<${DRONE_BUILD_LINK}|#${DRONE_BUILD_NUMBER}>"
+
+if [[ ${DRONE_BUILD_STATUS} == 'success' ]]; then
+  STATUS="${DRONE_BUILD_STATUS}%:thumbsup:"
+else
+  STATUS="${DRONE_BUILD_STATUS}%:x:"
+fi
+
+DURATION="$(($(date +%s) - $DRONE_BUILD_CREATED))%seconds"
+COMMIT="<${DRONE_COMMIT_LINK}|${DRONE_SOURCE_BRANCH}>"
+
+BULLETS=("Status" "Build" "Author" "Duration" "Commit")
+INFO=($STATUS $BUILD $DRONE_COMMIT_AUTHOR $DURATION $COMMIT)
+BODY="${HEADER}"
+
+for i in "${!BULLETS[@]}"; do
+  BODY="${BODY}\n• ${BULLETS[i]}: ${INFO[i]}"
+done
+
+BODY=$(echo $BODY | tr '%' ' ')
+
+security_post_data()
+{
+  cat <<EOF
+{
+  "blocks": [
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "$BODY"
+      },
+      "accessory": {
+				"type": "button",
+				"text": {
+					"type": "plain_text",
+					"text": "Pull Request",
+					"emoji": true
+				},
+				"value": "pull_request",
+				"url": "$DRONE_COMMIT_LINK"
+			}
+    }
+  ]
+}
+EOF
+}
+
+if [[ $1 == ${SLACK_SECURITY_CRON_WEBHOOK} ]]; then
+  BODY="$(security_post_data)"
+elif [[ $1 == ${SLACK_TEARDOWN_WEBHOOK} ]]; then
+  BODY="$(security_post_data)"
+elif [[ $1 == ${SLACK_DEPLOYMENT_WEBHOOK} ]]; then
+  BODY="$(security_post_data)"
+fi
+
+curl -i \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-X POST --data "$BODY" "$1"


### PR DESCRIPTION
## What?

These cron steps tear down the deployments which are scheduled to run weekly and are added to Drone yaml file and the cron schedule is added in Drone UI. These cron jobs are failing to teardown the deployments since they are setup. 

slack.sh file which is missing in bin folder. This slack file is used for sending notifications of build which are included in Drone pipeline

Please refer to the ticket for more information https://collaboration.homeoffice.gov.uk/jira/browse/PAF-192

## Why?
We need to resolve this Cron issue in PAF. We run a lot of Transient deployments on Kubernetes in branch Env for testing. These deployment consume Memory and vCPUs. We need to ensure that a cron task on every last day of week to clean up these resources. These deployments will redeployed using drone pipeline by team. 

## How?

I have recently ran this Cron job in Drone Debug mode. Using the Drone Command line terminal I have manually run the  command. It doesn't work with "sh" in command. When it is removed it is able to execute the command successfully and remove the deployment related workloads. I have compared with the other pipelines. it doesnt have the sh in command that is executed to tear down the deployments

## Testing?
After Merging to Master Branch we can add a a new Cron job (Create one for testing purpose) for testing in Drone that executes every hour. Please note that the weekly scheduled cron job will remain and it wont be updated.

## Screenshots (optional)
## Anything Else? (optional)
