### PR TITLE
Add exceptions to synk whitelist

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -58,4 +58,12 @@ ignore:
     - '*':
       reason: To be updated to a newer version in hof
       expires: '2024-11-01T17:02:21.865Z'
+  SNYK-JS-EXPRESS-6474509:
+    - '*':
+      reason: To be updated to a newer version in hof
+      expires: '2024-11-01T17:02:21.865Z'
+  SNYK-JS-FOLLOWREDIRECTS-6444610:
+    - '*':
+      reason: To be updated to a newer version in hof
+      expires: '2024-11-01T17:02:21.865Z'
 patch: {}


### PR DESCRIPTION
[PAF-257 - Pipeline failure on snyk_scan](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-257)

Two issues are identified by snyk scan:

"Open Redirect" [Medium Severity][https://security.snyk.io/vuln/SNYK-JS-EXPRESS-6474509] in express@4.18.2
    introduced by hof@20.4.0 > express@4.18.2 and 1 other path(s)

"Information Exposure" [Medium Severity][https://security.snyk.io/vuln/SNYK-JS-FOLLOWREDIRECTS-6444610] in follow-redirects@1.15.3
    introduced by hof@20.4.0 > notifications-node-client@6.0.0 > axios@0.25.0 > follow-redirects@1.15.3

Both have been whitelisted in PAF until they can be addressed in HOF.

