### PR TITLE
PAF-258 person-details Gender 

### DIFF
--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -1240,7 +1240,10 @@ module.exports = {
   personAddGender: {
     mixin: 'radio-group',
     isPageHeading: true,
-    parse: (value, field, req) => req.translate(`fields[${field}].options.[${value}]`),
+    parse: (value, field, req) => {
+      if (!value) return '';
+      return req.translate(`fields[${field}].options.[${value}]`)
+    },
     options: [
       'male',
       'female',

--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -1242,7 +1242,7 @@ module.exports = {
     isPageHeading: true,
     parse: (value, field, req) => {
       if (!value) return '';
-      return req.translate(`fields[${field}].options.[${value}]`)
+      return req.translate(`fields[${field}].options.[${value}]`);
     },
     options: [
       'male',


### PR DESCRIPTION
## What?

[ticket PAF-258](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-258)

/paf/person-details

Gender should be blank as user not selected any gender

Actual Result

`fields[personAddGender].options.[]`


## How?

The field parser was not handling the null case. It now returns the empty string.
