### PR TITLE
PAF-255 Country spelling correction

### DIFF
--- a/apps/paf/data/addPersonNationalities.json
+++ b/apps/paf/data/addPersonNationalities.json
@@ -648,8 +648,8 @@
     "label": "Peru"
   },
   {
-    "value": "Philipines",
-    "label": "Philipines"
+    "value": "Philippines",
+    "label": "Philippines"
   },
   {
     "value": "Polish",

--- a/apps/paf/data/nationalities.json
+++ b/apps/paf/data/nationalities.json
@@ -648,8 +648,8 @@
     "label": "Peru"
   },
   {
-    "value": "Nationality-Philipines",
-    "label": "Philipines"
+    "value": "Nationality-Philippines",
+    "label": "Philippines"
   },
   {
     "value": "Nationality-Polish",


### PR DESCRIPTION
## What?

[ticket PAF-255](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-255)

There were a couple of mis-spellings of Philippines in the country lists.

## Why?

It is important to have the correct spelling of Country names.

## How?

The mis-spelled words were identified and corrected.

## Testing?

Tested locally.

## Screenshots (optional)

Screenshots of a mis-spelling and a correct spelling are available in the ticket.
