### PR TITLE
PAF-261 email validation false negative

### DIFF
--- a/apps/paf/fields/index.js
+++ b/apps/paf/fields/index.js
@@ -1031,7 +1031,7 @@ module.exports = {
     validate: ['internationalPhoneNumber', { type: 'maxlength', arguments: 20 }]
   },
   'report-person-study-email': {
-    validate: ['notUrl', 'email', { type: 'maxlength', arguments: 100 }]
+    validate: ['email', { type: 'maxlength', arguments: 100 }]
   },
   'report-person-study-url': {
     mixin: 'input-text',

--- a/apps/paf/translations/src/en/validation.json
+++ b/apps/paf/translations/src/en/validation.json
@@ -248,8 +248,7 @@
   },
   "report-person-study-email": {
     "email": "There is a problem with the email you have entered. Please ensure it is not longer than 100 characters, it does not include invalid characters and it is in the format of <name>@<domain name> e.g. name@email.co.uk. If you do not know this information, please leave this field blank",
-    "maxlength": "You can't use more than {{maxlength}} characters for your answer",
-    "notUrl": "Enter a valid answer"
+    "maxlength": "You can't use more than {{maxlength}} characters for your answer"
   },
   "report-person-study-url": {
     "url": "Enter a website address in the correct format, like www.example.com",


### PR DESCRIPTION
## What?

email validation on the `paf/report-person-study-contact` page was reporting invalid on known valid email addresses.

## Why?

There was an additional validation on the `report-person-study-email` field preventing validation.

## How?

The `report-person-study-email` field requires only the `email` validator.

## Testing?

Tested locally

