### PR TITLE
PAF-264 fix prod integration, remove certs

### DIFF
--- a/kube/ims-resolver/ims-resolver-deploy.yml
+++ b/kube/ims-resolver/ims-resolver-deploy.yml
@@ -51,8 +51,12 @@ spec:
             - configMapRef:
                 name: imscertchain-store
           env:
-            - name: NODE_EXTRA_CA_CERTS
-              value: "/etc/ssl/certs/ims-prp1-ca.crt"
+            # PAF-264 Temp turn off certs to test the integration
+            - name: NODE_TLS_REJECT_UNAUTHORIZED
+              value: "0"
+            # PAF-264 Temp comment out to see if the app can send data without certs
+            # - name: NODE_EXTRA_CA_CERTS
+            #   value: "/etc/ssl/certs/ims-prp1-ca.crt"
             - name: TZ
               value: Europe/London
             - name: IMS_API_USER


### PR DESCRIPTION
## What?

* Remove secure connection and certs temporarily

## Why?

* Currently we can curl but we can't send data to IMS via the app, strip out this complexity to see if it helps