### PR TITLE
PAF-251 accessibility statement

### DIFF
--- a/apps/common/index.js
+++ b/apps/common/index.js
@@ -6,6 +6,9 @@ module.exports = {
     '/start': {
       template: 'start',
       next: 'paf/crime-type'
+    },
+    '/accessibility': {
+      template: 'accessibility'
     }
   }
 };

--- a/apps/common/translations/src/en/pages.json
+++ b/apps/common/translations/src/en/pages.json
@@ -4,5 +4,8 @@
   },
   "declaration": {
     "header": "Declaration"
+  },
+  "accessibility": {
+    "header": "Accessibility statement for this Home Office Forms Application"
   }
 }

--- a/apps/common/views/accessibility.html
+++ b/apps/common/views/accessibility.html
@@ -1,0 +1,5 @@
+{{<partials-page}}
+  {{$page-content}}
+    {{#markdown}}accessibility{{/markdown}}
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/common/views/content/accessibility.md
+++ b/apps/common/views/content/accessibility.md
@@ -1,0 +1,75 @@
+This accessibility statement applies to the Public Allegations Form on Home Office Forms.
+
+This website is run by Home Office. We want as many people as possible to be able to use this website. For example, that means you should be able to:
+
+- change colours, contrast levels and fonts using browser or device settings
+- zoom in up to 400% without the text spilling off the screen
+- navigate most of the website using a keyboard or speech recognition software
+- listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+
+We’ve also made the website text as simple as possible to understand.
+
+[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.
+
+## How accessible this website is
+
+We know some parts of this website are not fully accessible:
+
+- the user is not alerted when the 20 minute session is running out.
+- some screen readers (not including NVDA) may have difficulty in reading radio buttons with conditionally revealed fields.
+
+## Feedback and contact information 
+
+If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact:<br>[hof-accessibility@digital.homeoffice.gov.uk](hof-accessibility@digital.homeoffice.gov.uk)
+
+[Read tips on contacting organisations about inaccessible websites.](http://www.w3.org/WAI/users/inaccessible)
+
+## Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations'). If you're not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS).](https://www.equalityadvisoryservice.com/)
+
+If you are in Northern Ireland and are not happy with how we respond to your complaint you can contact the Equalities Commission for Northern Ireland who are responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations') in Northern Ireland.
+
+# Technical information about this website's accessibility
+The Home Office is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+
+## Compliance status
+
+This website is partially compliant with the [Web Content Accessibility Guidelines version 2.2](https://www.w3.org/TR/WCAG21/) AA standard, due to the non-compliances listed below.
+
+# Non-accessible Content
+
+The content listed below is non-accessible for the following reasons.
+
+## Non-compliance with the accessibility regulations
+
+We are aware of the following issues. 
+
+<ol class="list list-number">
+<li>The session timeout of 20 minutes cannot be changed and the user is not alerted when it is running out. This for each individual page of the form, not the form overall. This does not meet WCAG 2.2 Enough Time.</li>
+<li>Some screen reader users may have confusion with reading some radio buttons with conditionally revealed fields. When NVDA was used to test the screen reader the form was readable.</li>
+</ol>
+
+## Disproportionate burden
+
+At this time, we have not made any disproportionate burden claims.
+
+## Content that's not within the scope of the accessibility regulations
+
+At this time, this service does not contain any content that is exempt from the regulations
+
+# What we’re doing to improve accessibility
+
+We are developing functionality to alert the user their session is about to time out and allow them to extend the session. We are aiming to deliver this in Q2 2024.
+
+# Preparation of this accessibility statement
+
+This statement was prepared on 18 March 2024. It was last reviewed on 18 March 2024.
+
+This website was last tested on 18 March 2024 against the WCAG [2.1 or 2.2] AA standard.  
+
+The test was carried out as a self-assessment by the form team. The most viewed pages were tested using automated testing tools by our website team. A further audit of the website was carried out to the WCAG 2.2 AA standard.  
+
+We tested the service based on a user's ability to complete key journeys. All parts of the chosen journeys were tested, including documents. 
+
+Journeys were chosen on a number of factors including usage statistics, risk assessments and subject matter.

--- a/hof.settings.json
+++ b/hof.settings.json
@@ -12,5 +12,5 @@
   "session": {
     "name": "paf.hof.sid"
   },
-  "getAccessibility": true
+  "getAccessibility": false
 }

--- a/test/_unit/server.spec.js
+++ b/test/_unit/server.spec.js
@@ -48,18 +48,17 @@ describe('Server.js app file', () => {
   });
 
   describe('Setup HOF Configuration', () => {
-    it('calls hof with routes', () => {
-      hofStub.should.have.been.calledOnce.calledWithExactly({
-        appName: 'Public Allegations Form',
-        theme: 'govUK',
-        routes: [
-          appsCommonStub,
-          appsPafStub
-        ],
-        behaviours: [ behavioursSetNavigationSectionStub, behavioursTimeFormatterStub],
-        session: { name: 'paf.hof.sid' },
-        getAccessibility: true
-      });
+    it('calls hof with a suitable config', () => {
+      hofStub.should.have.been.calledOnce.calledWith(sinon.match({
+        appName: sinon.match.string,
+        theme: sinon.match.string,
+        routes: sinon.match.array,
+        behaviours: sinon.match.array,
+        session: sinon.match.object,
+        getAccessibility: sinon.match(function (value) { // Note: getAccessibility is now deprecated in hof
+          return value === undefined || typeof value === 'boolean';
+        }, 'getAccessibility should be undefined or a boolean')
+      }));
     });
 
     it('should call the app use method three times if env set to test', () => {


### PR DESCRIPTION
## What?

[PAF-251 - Update Accessibility Statement](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-251)

Add a PAF-specific Accessibility Statement.

## Why?

The HOF default Accessibility Statement is to be replaced with a PAF-specific version.

## How?

The HOF default AS page was disabled. A new static page was added at `/accessibility` via the "common" routes. The page is described in markdown. One point of interest is the css override required for a numbered list which are disabled by default in GDS.

## Testing?

Manual testing
