### PR TITLE
Update ims-resolver image to latest with reject failed msgs update

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -66,4 +66,8 @@ ignore:
     - '*':
       reason: To be updated to a newer version in hof
       expires: '2024-11-01T17:02:21.865Z'
+  SNYK-JS-BRACES-6838727:
+    - '*':
+      reason: To be updated to a newer version in hof
+      expires: '2024-08-16T17:02:21.865Z'
 patch: {}

--- a/kube/ims-resolver/ims-resolver-deploy.yml
+++ b/kube/ims-resolver/ims-resolver-deploy.yml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: ims-resolver
-          image: quay.io/ukhomeofficedigital/ims-resolver:904e940195bf741e15137cfa9f2fca61af704306
+          image: quay.io/ukhomeofficedigital/ims-resolver:b811bc0a37cb0b03c7b3ec15fa82ce9370118bf6
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
## What?

Update the ims-resolver image in its deployment.

The latest image contains the following updates:
- handleMessage function rejects its promise in the case of an error from its processing.
- Timestamps for error logs from handleMessage function
- Less generic logging

## Why?

According to the [SQS-consumer module docs](https://www.npmjs.com/package/sqs-consumer): "Throwing an error (or returning a rejected promise) from the handler function will cause the message to be left on the queue". 

Doing this will hopefully cause failed message processing to not crash the container due to handleException errors from node. It will also help any messages with critical failures to head to the dead letter queue. 

This rejection is present in the icasework resolver but has not been added to ims-resolver until now: https://github.com/UKHomeOffice/icasework-resolver/blob/master/index.js#L54