### PR TITLE
PAF-248 and PAF-292: Generate Filevault link to last forever instead of 7 days and revert ims-resolver pod replicas

### DIFF
--- a/apps/paf/models/file-upload.js
+++ b/apps/paf/models/file-upload.js
@@ -14,7 +14,6 @@ module.exports = class UploadModel extends Model {
 
   async save() {
     const result = await new Promise((resolve, reject) => {
-     // console.log("url: " + config.upload.hostname);
       const attributes = {
         url: config.upload.hostname
       };
@@ -36,7 +35,7 @@ module.exports = class UploadModel extends Model {
         return resolve(data);
       });
     });
-    this.set({ url: result.url });
+    this.set({ url: result.url.replace('/file/', '/file/generate-link/').split('?')[0] });
     return this.unset('data');
   }
 

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -35,8 +35,7 @@ spec:
     spec:
       containers:
         - name: file-vault
-          image: quay.io/ukhomeofficedigital/file-vault:bab000624c4323823cd4df723b44bc3bd29fec2c
-          # image: quay.io/ukhomeofficedigital/file-vault:ff139ae0ebaa279d51bc75610fc7999c2658450a
+          image: quay.io/ukhomeofficedigital/file-vault:f4cd1ece1caddc3bfbc8f5db761c593fda79ef12
           imagePullPolicy: Always
           resources:
             limits:
@@ -114,6 +113,8 @@ spec:
                 secretKeyRef:
                   name: ses
                   key: smtp_password
+            - name: ALLOW_GENERATE_LINK_ROUTE
+              value: "yes"
           securityContext:
             runAsNonRoot: true
 

--- a/kube/ims-resolver/ims-resolver-deploy.yml
+++ b/kube/ims-resolver/ims-resolver-deploy.yml
@@ -14,11 +14,7 @@ metadata:
   name: ims-resolver
   {{ end }}
 spec:
-  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV) }}
   replicas: 1
-  {{ else }}
-  replicas: 2
-  {{ end }}
   selector:
     matchLabels:
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}

--- a/kube/ims-resolver/ims-resolver-deploy.yml
+++ b/kube/ims-resolver/ims-resolver-deploy.yml
@@ -14,11 +14,8 @@ metadata:
   name: ims-resolver
   {{ end }}
 spec:
-  {{ if or (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV) }}
+  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV) }}
   replicas: 1
-  {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-  # This is a temporary measure to test a feature https://collaboration.homeoffice.gov.uk/jira/browse/PAF-284
-  replicas: 0
   {{ else }}
   replicas: 2
   {{ end }}

--- a/test/_unit/models/file-upload.spec.js
+++ b/test/_unit/models/file-upload.spec.js
@@ -28,24 +28,24 @@ describe('File Upload Model', () => {
       expect(response).to.be.an.instanceOf(Promise);
     });
 
-    // it('makes a call to file upload api', () => {
-    //   const model = new Model();
-    //   const response = model.save();
-    //   return response.then(() => {
-    //     expect(model.request).to.have.been.calledOnce;
-    //     expect(model.request).to.have.been.calledWith(sinon.match({
-    //       method: 'POST',
-    //       host: 'file-upload.example.com',
-    //       path: '/file/upload',
-    //       protocol: 'http:'
-    //     }));
-    //   });
-    // });
+    it('makes a call to file upload api', () => {
+      const model = new Model();
+      const response = model.save();
+      return response.then(() => {
+        expect(model.request).to.have.been.calledOnce;
+        expect(model.request).to.have.been.calledWith(sinon.match({
+          method: 'POST',
+          host: 'file-upload.example.com',
+          path: '/file/upload',
+          protocol: 'http:'
+        }));
+      });
+    });
 
     it('resolves with response from api endpoint', async () => {
       const model = new Model();
       const response = await model.save();
-      return expect(response.attributes.url).to.equal('/file/12341212132123?foo=bar');
+      return expect(response.attributes.url).to.equal('/file/generate-link/12341212132123');
     });
 
     it('rejects if api call fails', () => {


### PR DESCRIPTION
## What?
- Generate Filevault link to last forever instead of 7 days - [PAF-284](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-284)
- Revert ims-resolver pod replica to 1 - [PAF-292](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-292)
## Why?
- Currently the expiry time for filevault links  for PAF is 7 days. This change will ensure the link lasts forever to prevent being unable to access attachments particularly when the IMS casework system goes down before forms have been successfully sent.
- A 'deadlock' error was triggered when the replicas were increased to 2 on prod so they have been reverted to 1 to avoid this error (previous changes to increase memory should continue to prevent 'out of memory' errors - ([PAF-289](https://github.com/jira/browse/PAF-289))).
## How?
- Amended the file upload model to replace url route with 'file/generate-link'
- Added the ALLOW_GENERATE_LINK ROUTE environment variable to the file vault-deployment yaml and set it to 'yes'
- Amended relevant tests
- reverted ims-resolver replicas to 1
## Testing?
- tests passing locally
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
