### PR TITLE
PAF-289: Update Replicas count to 2 for ims-resolver in prod and to 0 for ims-resolver in branch

### DIFF
--- a/kube/ims-resolver/ims-resolver-deploy.yml
+++ b/kube/ims-resolver/ims-resolver-deploy.yml
@@ -15,7 +15,7 @@ metadata:
   {{ end }}
 spec:
   {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV) }}
-  replicas: 1
+  replicas: 0
   {{ else }}
   replicas: 2
   {{ end }}

--- a/kube/ims-resolver/ims-resolver-deploy.yml
+++ b/kube/ims-resolver/ims-resolver-deploy.yml
@@ -17,6 +17,7 @@ spec:
   {{ if or (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV) }}
   replicas: 1
   {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+  # This is a temporary measure to test a feature https://collaboration.homeoffice.gov.uk/jira/browse/PAF-284
   replicas: 0
   {{ else }}
   replicas: 2

--- a/kube/ims-resolver/ims-resolver-deploy.yml
+++ b/kube/ims-resolver/ims-resolver-deploy.yml
@@ -14,7 +14,9 @@ metadata:
   name: ims-resolver
   {{ end }}
 spec:
-  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV) }}
+  {{ if or (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV) }}
+  replicas: 1
+  {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
   replicas: 0
   {{ else }}
   replicas: 2

--- a/kube/ims-resolver/ims-resolver-deploy.yml
+++ b/kube/ims-resolver/ims-resolver-deploy.yml
@@ -14,7 +14,11 @@ metadata:
   name: ims-resolver
   {{ end }}
 spec:
+  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) (eq .KUBE_NAMESPACE .STG_ENV) }}
   replicas: 1
+  {{ else }}
+  replicas: 2
+  {{ end }}
   selector:
     matchLabels:
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}


### PR DESCRIPTION
## What?
* IMS-resolver in production is being tested with 2 replicas.
* Team working on adding features in Branch
* PAF-248 requires replicas to be set to zero for branch

## Why?
These changes are required for the IMS-Resolver which can be seen having Out of Memory issue resulting in restarts.
This Ensures there is always a stable set of running pods. It also Guarantee the availability of a specified number of identical Pods

## How?
Adding the If condition to apply these changes only to the deployment in Production.

## Testing?
We will be monitoring the pod and this should eventually resolved the issues with memory

## Screenshots (optional)
## Anything Else? (optional)
We are waiting for ACP to add Visibility Time out for SQS queue.
https://support.acp.homeoffice.gov.uk/servicedesk/customer/portal/1/ACP-19768



We are also looking at adding Auto Scaling

## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
