### PR TITLE
 'DO NOT MERGE'  HOFF-729-fix-security-vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "accessible-autocomplete": "^2.0.2",
     "busboy-body-parser": "^0.3.2",
     "device": "^0.3.12",
-    "hof": "^20.4.0",
+    "hof": "20.4.1-minimatch-vulnerability-beta",
     "jquery": "^3.3.1",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3865,10 +3865,10 @@ govuk-elements-sass@^3.1.3:
   dependencies:
     govuk_frontend_toolkit "^7.1.0"
 
-govuk-frontend@3.15:
-  version "3.15.0"
-  resolved "https://registry.npmmirror.com/govuk-frontend/-/govuk-frontend-3.15.0.tgz"
-  integrity sha512-kInDei8hrkMcrW7yC2EwhbSNBOBBPTdLxIDAye2G7KNrD9cyvNAfd0KchrfP/nWBOzu67ANoz2rtoRDLWiBN2w==
+govuk-frontend@3.14:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.14.0.tgz#d3a9c54437c08f5188f87b1f4480ba60e95c8eb6"
+  integrity sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA==
 
 govuk_frontend_toolkit@^7.1.0:
   version "7.6.0"
@@ -4035,10 +4035,10 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hof@^20.4.0:
-  version "20.4.0"
-  resolved "https://registry.npmmirror.com/hof/-/hof-20.4.0.tgz"
-  integrity sha512-tGVUSHZUzlisy4fyqMuZr2knzolawnD2KQuG4MXTtcjOZ2+XQSYsMoCFlplJyGW9yUKdkhV8JIsaaiRd7GqajA==
+hof@20.4.1-minimatch-vulnerability-beta:
+  version "20.4.1-minimatch-vulnerability-beta"
+  resolved "https://registry.yarnpkg.com/hof/-/hof-20.4.1-minimatch-vulnerability-beta.tgz#410fc67aa0bf317113a692b202dcf4d23f63fc77"
+  integrity sha512-Jgf6KqgmB3rjBDeUI07OOsWGVPFa2z5JfNAsmO69i7OlN/b5ZiQ+xALxz/uYV4smDeH/Nj9ofMBlYKtU3liBNw==
   dependencies:
     aliasify "^2.1.0"
     bluebird "^3.7.2"
@@ -4062,7 +4062,7 @@ hof@^20.4.0:
     findup "^0.1.5"
     glob "^7.2.0"
     govuk-elements-sass "^3.1.3"
-    govuk-frontend "3.15"
+    govuk-frontend "3.14"
     govuk_template_mustache "^0.26.0"
     helmet "^3.22.0"
     hogan-express-strict "^0.5.4"
@@ -4071,7 +4071,7 @@ hof@^20.4.0:
     i18n-future "^2.0.0"
     i18n-lookup "^0.1.0"
     is-pdf "^1.0.0"
-    libphonenumber-js "^1.9.44"
+    libphonenumber-js "^1.9.37"
     lodash "^4.17.21"
     markdown-it "^12.3.2"
     minimatch "^3.0.7"
@@ -4820,10 +4820,10 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-libphonenumber-js@^1.9.44:
-  version "1.10.51"
-  resolved "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.51.tgz"
-  integrity sha512-vY2I+rQwrDQzoPds0JeTEpeWzbUJgqoV0O4v31PauHBb/e+1KCXKylHcDnBMgJZ9fH9mErsEbROJY3Z3JtqEmg==
+libphonenumber-js@^1.9.37:
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.11.5.tgz#50a441da5ff9ed9a322d796a14f1e9cbc0fdabdf"
+  integrity sha512-TwHR5BZxGRODtAfz03szucAkjT5OArXr+94SMtAM2pYXIlQNVMrxvb6uSCbnaJJV6QXEyICk7+l6QPgn72WHhg==
 
 linkify-it@^3.0.1:
   version "3.0.3"


### PR DESCRIPTION
## What?
- Fix-medium-security-vulnerability - [HOFF-729](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-729) 
## Why?
HOF version has changed so we need to check it is not breaking
## How?
- HOF version has changed to 20.4.1-minimatch-vulnerability-beta
- yarn.lock file updated
## Testing?
tests passing

## Check list

- [x] I have reviewed my own pull request for linting issues
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
