### PR TITLE
PAF-286 Bugfix for About you Nav

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -70,6 +70,18 @@ ignore:
     - '*':
       reason: To be updated to a newer version in hof
       expires: '2024-08-16T17:02:21.865Z'
+  SNYK-JS-ELLIPTIC-7577916:
+    - '*':
+      reason: To be updated to a newer version in hof
+      expires: '2024-11-16T17:02:21.865Z'
+  SNYK-JS-ELLIPTIC-7577917:
+    - '*':
+      reason: To be updated to a newer version in hof
+      expires: '2024-11-16T17:02:21.865Z'
+  SNYK-JS-ELLIPTIC-7577918:
+    - '*':
+      reason: To be updated to a newer version in hof
+      expires: '2024-11-16T17:02:21.865Z'
   SNYK-JS-FASTXMLPARSER-7573289:
     - '*':
       reason: This issue was fixed in versions 4.4.1

--- a/apps/paf/behaviours/set-navigation-section.js
+++ b/apps/paf/behaviours/set-navigation-section.js
@@ -74,8 +74,7 @@ module.exports = superclass => class extends superclass {
           res.locals.backLink = 'report-organisation';
         }
       }
-
-
+      
       // About You section - set next property for preceeding pages and set backlink
       if (req.query.section === 'about-you') {
         req.form.options.steps['/other-info-file-upload'].next = '/about-you';
@@ -95,7 +94,10 @@ module.exports = superclass => class extends superclass {
           res.locals.backLink = 'other-info-file-upload';
         }
       }
-
+      if (req.sessionModel.get('images') && req.sessionModel.get('images').length > 0) {
+        req.form.options.steps['/about-you'].backLink = 'add-other-info-file-upload';
+        res.locals.backLink = 'add-other-info-file-upload';
+      }
 
       // Check Answers section - set next property for preceeding pages and set backlink
       if (req.query.section === 'check-answers') {

--- a/apps/paf/index.js
+++ b/apps/paf/index.js
@@ -718,8 +718,7 @@ module.exports = {
           }
           return false;
         }
-      }],
-      next: '/about-you'
+      }]
     },
     '/add-other-info-file-upload': {
       template: 'list-add-looped-files',
@@ -733,7 +732,6 @@ module.exports = {
         combineValuesToSingleField: 'record',
         returnTo: '/other-info-file-upload'
       }), removeImage, limitDocs],
-      next: '/about-you',
       locals: {
         section: 'other-info-file-upload'
       }

--- a/test/_unit/behaviours/set-navigation-section.spec.js
+++ b/test/_unit/behaviours/set-navigation-section.spec.js
@@ -2,6 +2,7 @@
 /* eslint-disable max-len */
 const Controller = require('hof').controller;
 const Behaviour = require('../../../apps/paf/behaviours/set-navigation-section');
+const Model = require('hof').model;
 
 describe('apps/paf/behaviours/set-navigation-section', () => {
   describe('getValues', () => {
@@ -13,6 +14,7 @@ describe('apps/paf/behaviours/set-navigation-section', () => {
     beforeEach(done => {
       req = reqres.req();
       res = reqres.res();
+      req.sessionModel = new Model({});
       req.sessionModel.attributes.steps = [];
 
       const GetSectionController = Behaviour(Controller);
@@ -238,12 +240,40 @@ describe('apps/paf/behaviours/set-navigation-section', () => {
         });
       });
 
-      it('has the other-info-file-upload backlink for the about-you page', () => {
+      it('has the other-info-file-upload backlink for the about-you page if no files have been uploaded', () => {
         req.form.options.route = '/about-you';
+        req.sessionModel.set('images', []);
         req.sessionModel.attributes.steps.push('/other-info-file-upload');
         controller.getValues(req, res, () => {
           req.form.options.steps['/about-you'].backLink.should.deep.equal('other-info-file-upload');
           res.locals.backLink.should.deep.equal('other-info-file-upload');
+        });
+      });
+
+      it('has the add-other-info-file-upload backlink for the about-you page if files have been uploaded', () => {
+        const images = [{
+          name: 'violin.png',
+          mimetype: 'image/png',
+          id: 'a1',
+          url: 'http://s3.com/foo/0.4283270873546463'
+        },
+        {
+          name: 'piano.png',
+          mimetype: 'image/png',
+          id: 'b2',
+          url: 'http://s3.com/foo/0.4283270873546464'
+        },
+        {
+          name: 'piano.png',
+          mimetype: 'image/png',
+          id: 'b2',
+          url: 'http://s3.com/foo/0.4283270873546465'
+        }];
+        req.form.options.route = '/about-you';
+        req.sessionModel.set('images', images);
+        controller.getValues(req, res, () => {
+          req.form.options.steps['/about-you'].backLink.should.deep.equal('add-other-info-file-upload');
+          res.locals.backLink.should.deep.equal('add-other-info-file-upload');
         });
       });
 


### PR DESCRIPTION
## What?
[PAF-286](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-286) - About you navigation button not working.

## Why?
When about you button is clicked, it redirect to different page 

## How?
- Removed the next property from the "/add-other-info-file-upload and /other-info-file-upload" in the index.js file. this will redirect to url to the last completed form is about you is clicked

- Added a few line in the set-navigation-section.js to handle the back button functionalities to enable user navigate to previous step list.

- Added test line to confirm it redirect correctly.

## Testing?
Tested on local machine. 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
