### PR TITLE
Fix: remove .only from unit test

### DIFF
--- a/test/_unit/models/file-upload.spec.js
+++ b/test/_unit/models/file-upload.spec.js
@@ -5,7 +5,7 @@ const Model = require('../../../apps/paf/models/file-upload');
 const config = require('../../../config');
 const FormData = require('form-data');
 
-describe.only('File Upload Model', () => {
+describe('File Upload Model', () => {
   let sandbox;
 
   beforeEach(function () {


### PR DESCRIPTION
## What?
Remove .only from describe block
## Why?
Unit tests are currently only running one test
## How?
- remove .only from describe block in file-upload.spec.js
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
