### PR TITLE
PAF-304: Remove '.only' from file-upload unit test to run all unit tests

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,10 +2,6 @@
 version: v1.19.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-JS-REQUEST-3361831:
-  - '*':
-      reason: No upgrade or patch available
-      expires: '2024-11-01T17:02:21.865Z'
   SNYK-JS-XML2JS-5414874:
   - '*':
       reason: No direct upgrade or patch available
@@ -22,43 +18,7 @@ ignore:
     - '*':
       reason: No upgrade or patch available
       expires: '2024-11-01T17:02:21.865Z'
-  SNYK-JS-USERAGENT-174737:
-    - '*':
-      reason: No upgrade or patch available
-      expires: '2024-11-01T17:02:21.865Z'
-  SNYK-JS-AXIOS-6032459:
-    - '*':
-      reason: To be updated to a newer version in hof
-      expires: '2024-11-01T17:02:21.865Z'
-  SNYK-JS-AXIOS-6124857:
-    - '*':
-      reason: To be updated to a newer version in hof
-      expires: '2024-11-01T17:02:21.865Z'
-  SNYK-JS-AXIOS-6144788:
-    - '*':
-      reason: To be updated to a newer version in hof
-      expires: '2024-11-01T17:02:21.865Z'
-  SNYK-JS-FOLLOWREDIRECTS-6141137:
-    - '*':
-      reason: To be updated to a newer version in hof
-      expires: '2024-11-01T17:02:21.865Z'
-  SNYK-JS-INFLIGHT-6095116:
-    - '*':
-      reason: To be updated to a newer version in hof
-      expires: '2024-11-01T17:02:21.865Z'
-  SNYK-JS-NODEMAILER-6219989:
-    - '*':
-      reason: To be updated to a newer version in hof
-      expires: '2024-11-01T17:02:21.865Z'
-  SNYK-JS-TOUGHCOOKIE-5672873:
-    - '*':
-      reason: To be updated to a newer version in hof
-      expires: '2024-11-01T17:02:21.865Z'
   SNYK-JS-MARKDOWNIT-6483324:
-    - '*':
-      reason: To be updated to a newer version in hof
-      expires: '2024-11-01T17:02:21.865Z'
-  SNYK-JS-EXPRESS-6474509:
     - '*':
       reason: To be updated to a newer version in hof
       expires: '2024-11-01T17:02:21.865Z'
@@ -66,10 +26,6 @@ ignore:
     - '*':
       reason: To be updated to a newer version in hof
       expires: '2024-11-01T17:02:21.865Z'
-  SNYK-JS-BRACES-6838727:
-    - '*':
-      reason: To be updated to a newer version in hof
-      expires: '2024-08-16T17:02:21.865Z'
   SNYK-JS-ELLIPTIC-7577916:
     - '*':
       reason: To be updated to a newer version in hof
@@ -86,4 +42,13 @@ ignore:
     - '*':
       reason: This issue was fixed in versions 4.4.1
       expires: '2024-11-01T17:02:21.865Z'
+  SNYK-JS-COOKIE-8163060:
+    - '*':
+      reason: No upgrade or patch available
+      expires: '2025-01-24T17:02:21.865Z'
+  SNYK-JS-ELLIPTIC-8187303:
+    - '*':
+      reason: No upgrade or patch available
+      expires: '2025-01-24T17:02:21.865Z'
+
 patch: {}

--- a/test/_unit/models/file-upload.spec.js
+++ b/test/_unit/models/file-upload.spec.js
@@ -5,7 +5,7 @@ const Model = require('../../../apps/paf/models/file-upload');
 const config = require('../../../config');
 const FormData = require('form-data');
 
-describe.only('File Upload Model', () => {
+describe('File Upload Model', () => {
   let sandbox;
 
   beforeEach(function () {


### PR DESCRIPTION
## What?
Remove .only from describe block in file-upload unit test - [PAF-304](https://collaboration.homeoffice.gov.uk/jira/browse/PAF-304)
## Why?
Unit tests are currently only running one test
## How?
- remove .only from describe block in file-upload.spec.js
## Testing?
test passing locally and on branch
## Screenshots (optional)
## Anything Else? (optional)
- updated snyk list
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
