### PR TITLE
HOTFIX: Fix drone  get pr branch step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -253,7 +253,7 @@ steps:
       - name: dockersock
         path: /root/.dockersock
     commands:
-      - drone build info $GIT_REPO $DRONE_BUILD_NUMBER --format {{.Message}} | grep -o '[^ ]\+$' -m1 | sed 's|UKHomeOffice/||g' | tr '[:upper:]' '[:lower:]' | tr '/' '-' > /root/.dockersock/branch_name.txt
+      - drone build info --server "$DRONE_SERVER" --token "$DRONE_TOKEN" $GIT_REPO $DRONE_BUILD_NUMBER --format {{.Message}} | grep -o '[^ ]\+$' -m1 | sed 's|UKHomeOffice/||g' | tr '[:upper:]' '[:lower:]' | tr '/' '-' > /root/.dockersock/branch_name.txt
     when:
       branch:
         <<: *include_default_branch


### PR DESCRIPTION
## What?
Fix drone get pr branch step 
## Why?
Get pr branch blocking sanity check on prod deployment build - `parse  ******api/repos/UKHomeOffice/paf/builds/1873: first path segment in URL cannot contain colon`
## How?
amended the get request to explixilty include the drone server and drone token.
## Testing?
tested in branch using pull request event
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
