### PR TITLE
HOTFIX: Fix Prod build issue

### DIFF
--- a/bin/sanity_check_build.sh
+++ b/bin/sanity_check_build.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 set -e
 
-export STATUS=$(drone build info $GIT_REPO $DRONE_BUILD_PARENT --format {{.Status}})
-export BRANCH=$(drone build info $GIT_REPO $DRONE_BUILD_PARENT --format {{.Target}})
-export EVENT=$(drone build info $GIT_REPO $DRONE_BUILD_PARENT --format {{.Event}})
-export REFS=$(drone build info $GIT_REPO $DRONE_BUILD_PARENT --format {{.Ref}})
+export STATUS=$(drone build info --server "$DRONE_SERVER" --token "$DRONE_TOKEN" $GIT_REPO $DRONE_BUILD_PARENT --format {{.Status}})
+export BRANCH=$(drone build info --server "$DRONE_SERVER" --token "$DRONE_TOKEN" $GIT_REPO $DRONE_BUILD_PARENT --format {{.Target}})
+export EVENT=$(drone build info --server "$DRONE_SERVER" --token "$DRONE_TOKEN" $GIT_REPO $DRONE_BUILD_PARENT --format {{.Event}})
+export REFS=$(drone build info --server "$DRONE_SERVER" --token "$DRONE_TOKEN" $GIT_REPO $DRONE_BUILD_PARENT --format {{.Ref}})
 
 if [[ "$STATUS" != "success" ]]; then
   echo "Build number $DRONE_BUILD_PARENT failed due to unsuccessful status."


### PR DESCRIPTION
## What?
Fix drone get pr branch step 
## Why?
Get pr branch blocking sanity check on prod deployment build - `parse  ******api/repos/UKHomeOffice/paf/builds/1873: first path segment in URL cannot contain colon`
## How?
amended the get request to explixilty include the drone server and drone token.
## Testing?
tested in branch using pull request event
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
