### PR TITLE
HOTFIX: Fix drone get pr branch step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -253,7 +253,7 @@ steps:
       - name: dockersock
         path: /root/.dockersock
     commands:
-      - drone build info --server "$DRONE_SERVER" --token "$DRONE_TOKEN" $GIT_REPO $DRONE_BUILD_NUMBER --format {{.Message}} | grep -o '[^ ]\+$' -m1 | sed 's|UKHomeOffice/||g' | tr '[:upper:]' '[:lower:]' | tr '/' '-' > /root/.dockersock/branch_name.txt
+      - drone build info $GIT_REPO $DRONE_BUILD_NUMBER --format {{.Message}} | grep -o '[^ ]\+$' -m1 | sed 's|UKHomeOffice/||g' | tr '[:upper:]' '[:lower:]' | tr '/' '-' > /root/.dockersock/branch_name.txt
     when:
       branch:
         <<: *include_default_branch
@@ -329,21 +329,21 @@ steps:
       event: promote
 
   # Deploy to Production environment
-  - name: deploy_to_prod
-    pull: if-not-exists
-    image: quay.io/ukhomeofficedigital/kd:v1.14.0
-    environment:
-      KUBE_SERVER:
-        from_secret: kube_server_prod
-      KUBE_TOKEN:
-        from_secret: kube_token_prod
-    commands:
-      - bin/deploy.sh $${PROD_ENV}
-    when:
-      target: PROD
-      event: promote
-    depends_on:
-      - clone_repos_prod
+  # - name: deploy_to_prod
+  #   pull: if-not-exists
+  #   image: quay.io/ukhomeofficedigital/kd:v1.14.0
+  #   environment:
+  #     KUBE_SERVER:
+  #       from_secret: kube_server_prod
+  #     KUBE_TOKEN:
+  #       from_secret: kube_token_prod
+  #   commands:
+  #     - bin/deploy.sh $${PROD_ENV}
+  #   when:
+  #     target: PROD
+  #     event: promote
+  #   depends_on:
+  #     - clone_repos_prod
 
 # CRON job step that tears down our pull request UAT environments
   - name: cron_tear_down

--- a/bin/sanity_check_build.sh
+++ b/bin/sanity_check_build.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 set -e
 
-export STATUS=$(drone build info --server "$DRONE_SERVER" --token "$DRONE_TOKEN" $GIT_REPO $DRONE_BUILD_PARENT --format {{.Status}})
-export BRANCH=$(drone build info --server "$DRONE_SERVER" --token "$DRONE_TOKEN" $GIT_REPO $DRONE_BUILD_PARENT --format {{.Target}})
-export EVENT=$(drone build info --server "$DRONE_SERVER" --token "$DRONE_TOKEN" $GIT_REPO $DRONE_BUILD_PARENT --format {{.Event}})
-export REFS=$(drone build info --server "$DRONE_SERVER" --token "$DRONE_TOKEN" $GIT_REPO $DRONE_BUILD_PARENT --format {{.Ref}})
+export STATUS=$(drone build info $GIT_REPO $DRONE_BUILD_PARENT --format {{.Status}})
+export BRANCH=$(drone build info $GIT_REPO $DRONE_BUILD_PARENT --format {{.Target}})
+export EVENT=$(drone build info $GIT_REPO $DRONE_BUILD_PARENT --format {{.Event}})
+export REFS=$(drone build info $GIT_REPO $DRONE_BUILD_PARENT --format {{.Ref}})
 
 if [[ "$STATUS" != "success" ]]; then
   echo "Build number $DRONE_BUILD_PARENT failed due to unsuccessful status."


### PR DESCRIPTION
## What?
Fix drone get pr branch step 
## Why?
Get pr branch blocking sanity check on prod deployment build - `parse  ******api/repos/UKHomeOffice/paf/builds/1873: first path segment in URL cannot contain colon`
## How?
- updated drone server and token secrets
- remove unnecessary flags from get pr branch step and sanity checks script
- commented out deploy to prod stage temporarily to test sanity checks
## Testing?
tested in branch using pull request event
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
