### PR TITLE
HOTFIX: Uncomment deploy to prod stage

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -329,21 +329,21 @@ steps:
       event: promote
 
   # Deploy to Production environment
-  # - name: deploy_to_prod
-  #   pull: if-not-exists
-  #   image: quay.io/ukhomeofficedigital/kd:v1.14.0
-  #   environment:
-  #     KUBE_SERVER:
-  #       from_secret: kube_server_prod
-  #     KUBE_TOKEN:
-  #       from_secret: kube_token_prod
-  #   commands:
-  #     - bin/deploy.sh $${PROD_ENV}
-  #   when:
-  #     target: PROD
-  #     event: promote
-  #   depends_on:
-  #     - clone_repos_prod
+  - name: deploy_to_prod
+    pull: if-not-exists
+    image: quay.io/ukhomeofficedigital/kd:v1.14.0
+    environment:
+      KUBE_SERVER:
+        from_secret: kube_server_prod
+      KUBE_TOKEN:
+        from_secret: kube_token_prod
+    commands:
+      - bin/deploy.sh $${PROD_ENV}
+    when:
+      target: PROD
+      event: promote
+    depends_on:
+      - clone_repos_prod
 
 # CRON job step that tears down our pull request UAT environments
   - name: cron_tear_down


### PR DESCRIPTION
## What?
Uncomment deploy to prod stage part of hotfixing Fix drone get pr branch step 
## Why?
Get pr branch blocking sanity check on prod deployment build - `parse  ******api/repos/UKHomeOffice/paf/builds/1873: first path segment in URL cannot contain colon`
## How?
- uncommented deploy to prod stage which was commented out to temporarily to test sanity checks on deployment
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
